### PR TITLE
Remove once_cell::sync::Lazy in favor of std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,6 @@ dependencies = [
  "clap",
  "colored",
  "crossterm",
- "once_cell",
  "rand",
  "sysinfo",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ colored = "2.1"
 clap = { version = "4.5", features = ["derive"] }
 sysinfo = "0.32"
 chrono = "0.4"
-once_cell = "1.21.3"

--- a/src/log_generator.rs
+++ b/src/log_generator.rs
@@ -1,11 +1,10 @@
-use std::sync::Mutex;
-use once_cell::sync::Lazy;
+use std::sync::{Mutex, LazyLock};
 use rand::Rng;
 
 #[allow(dead_code)]
 pub struct LogGenerator;
 
-static LAST_TIMESTAMP: Lazy<Mutex<f64>> = Lazy::new(|| Mutex::new(0.0));
+static LAST_TIMESTAMP: LazyLock<Mutex<f64>> = LazyLock::new(|| Mutex::new(0.0));
 
 impl LogGenerator {
     pub fn timestamp() -> String {


### PR DESCRIPTION
once_cell is largely unneeded in modern Rust as it's mostly been added to the standard library.