### PR TITLE
fix: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "install-nothing"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "install-nothing"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Kerim Buyukakyuz"]
 description = "A nostalgic infinite installer simulator"


### PR DESCRIPTION
fix: bump version to 0.5.0 to match with the release

- https://github.com/Homebrew/homebrew-core/pull/258981