### PR TITLE
Add --flavor flag for opsec vs occult themes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Test
+        run: cargo test --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v*'
   workflow_dispatch:
@@ -10,8 +11,39 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  version:
+    name: Determine Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag_name: ${{ steps.get_version.outputs.tag_name }}
+      is_new_release: ${{ steps.check_tag.outputs.is_new }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from Cargo.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_name=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          TAG_NAME="v$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')"
+          if git ls-remote --tags origin "$TAG_NAME" | grep -q "$TAG_NAME"; then
+            echo "is_new=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG_NAME already exists, skipping release"
+          else
+            echo "is_new=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG_NAME is new, will create release"
+          fi
+
   build:
     name: Build ${{ matrix.target }}
+    needs: version
+    if: needs.version.outputs.is_new_release == 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,12 +102,13 @@ jobs:
 
   release:
     name: Create Release
-    needs: build
+    needs: [version, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -99,8 +132,17 @@ jobs:
 
           cp artifacts/cursed-install-windows-x86_64.exe/cursed-install.exe release/cursed-install-windows-x86_64.exe
 
+      - name: Create tag
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        env:
+          TAG_NAME: ${{ needs.version.outputs.tag_name }}
+        run: |
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.version.outputs.tag_name }}
           files: release/*
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,28 +19,28 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact_name: install-nothing
-            asset_name: install-nothing-linux-x86_64
+            artifact_name: cursed-install
+            asset_name: cursed-install-linux-x86_64
 
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact_name: install-nothing
-            asset_name: install-nothing-linux-aarch64
+            artifact_name: cursed-install
+            asset_name: cursed-install-linux-aarch64
 
           - target: x86_64-apple-darwin
             os: macos-latest
-            artifact_name: install-nothing
-            asset_name: install-nothing-macos-x86_64
+            artifact_name: cursed-install
+            asset_name: cursed-install-macos-x86_64
 
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact_name: install-nothing
-            asset_name: install-nothing-macos-aarch64
+            artifact_name: cursed-install
+            asset_name: cursed-install-macos-aarch64
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            artifact_name: install-nothing.exe
-            asset_name: install-nothing-windows-x86_64.exe
+            artifact_name: cursed-install.exe
+            asset_name: cursed-install-windows-x86_64.exe
 
     steps:
       - name: Checkout
@@ -85,19 +85,19 @@ jobs:
         run: |
           mkdir -p release
 
-          cp artifacts/install-nothing-linux-x86_64/install-nothing release/install-nothing-linux-x86_64
-          chmod +x release/install-nothing-linux-x86_64
+          cp artifacts/cursed-install-linux-x86_64/cursed-install release/cursed-install-linux-x86_64
+          chmod +x release/cursed-install-linux-x86_64
 
-          cp artifacts/install-nothing-linux-aarch64/install-nothing release/install-nothing-linux-aarch64
-          chmod +x release/install-nothing-linux-aarch64
+          cp artifacts/cursed-install-linux-aarch64/cursed-install release/cursed-install-linux-aarch64
+          chmod +x release/cursed-install-linux-aarch64
 
-          cp artifacts/install-nothing-macos-x86_64/install-nothing release/install-nothing-macos-x86_64
-          chmod +x release/install-nothing-macos-x86_64
+          cp artifacts/cursed-install-macos-x86_64/cursed-install release/cursed-install-macos-x86_64
+          chmod +x release/cursed-install-macos-x86_64
 
-          cp artifacts/install-nothing-macos-aarch64/install-nothing release/install-nothing-macos-aarch64
-          chmod +x release/install-nothing-macos-aarch64
+          cp artifacts/cursed-install-macos-aarch64/cursed-install release/cursed-install-macos-aarch64
+          chmod +x release/cursed-install-macos-aarch64
 
-          cp artifacts/install-nothing-windows-x86_64.exe/install-nothing.exe release/install-nothing-windows-x86_64.exe
+          cp artifacts/cursed-install-windows-x86_64.exe/cursed-install.exe release/cursed-install-windows-x86_64.exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursed-install"
+version = "0.6.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "colored",
+ "crossterm",
+ "rand",
+ "sysinfo",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,18 +283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "install-nothing"
-version = "0.5.0"
-dependencies = [
- "chrono",
- "clap",
- "colored",
- "crossterm",
- "rand",
- "sysinfo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "install-nothing"
-version = "0.5.0"
+name = "cursed-install"
+version = "0.6.0"
 edition = "2021"
-authors = ["Kerim Buyukakyuz"]
-description = "A nostalgic infinite installer simulator"
+authors = ["Kerim Buyukakyuz", "Mark Riechers"]
+description = "A nostalgic infinite installer simulator that knows too much about you"
 
 [dependencies]
 crossterm = "0.27"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
-COPY --from=builder /app/target/release/install-nothing /usr/local/bin/install-nothing
+COPY --from=builder /app/target/release/cursed-install /usr/local/bin/cursed-install
 
 RUN useradd -m -u 1000 -U appuser
 USER appuser
 
-ENTRYPOINT ["install-nothing"]
+ENTRYPOINT ["cursed-install"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# install-nothing
+# cursed-install
 
 A terminal application that simulates installing things. It doesn't actually install anything.
 
@@ -10,11 +10,11 @@ But it might know more about you than you'd expect.
 
 ### Download binary
 
-Grab the latest binary for your platform from [Releases](https://github.com/buyukakyuz/install-nothing/releases)
+Grab the latest binary for your platform from [Releases](https://github.com/MarkOnFire/cursed-install/releases)
 
 ```bash
-chmod +x install-nothing-*
-./install-nothing-linux-x86_64
+chmod +x cursed-install-*
+./cursed-install-linux-x86_64
 ```
 
 ### Build from source
@@ -99,12 +99,12 @@ All scan results stay in memory for the duration of the process and are discarde
 
 Build
 ```bash
-docker build -t install-nothing .
+docker build -t cursed-install .
 ```
 
 Run
 ```bash
-docker run -it --rm --init install-nothing
+docker run -it --rm --init cursed-install
 ```
 
 Note: awareness mode has limited data in Docker containers (no home directory, no browser profiles, etc.). The installer gracefully falls back to generic messages.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A terminal application that simulates installing things. It doesn't actually install anything.
 
+But it might know more about you than you'd expect.
+
 [![asciicast](https://asciinema.org/a/757039.svg)](https://asciinema.org/a/757039)
 
 ## Installation
@@ -21,7 +23,7 @@ chmod +x install-nothing-*
 cargo run --release
 ```
 
-Press Ctrl+C to stop.
+Press Ctrl+C to stop. Or try to.
 
 ### Pick what to install
 
@@ -42,6 +44,56 @@ See available stages:
 cargo run --release -- --help
 ```
 
+## Awareness Mode
+
+By default, the installer scans your filesystem at startup and uses what it finds to generate progressively unsettling messages. The longer you let it run, the more personal it gets.
+
+This serves as a (humorous) reminder of what any program you run can learn about you — just from filenames, directory listings, and existence checks. It never reads file contents.
+
+### Escalation tiers
+
+The installer's tone escalates across installation cycles:
+
+| Cycle | Tier | Tone |
+|-------|------|------|
+| 1 | Baseline | Normal (classic behavior) |
+| 2-3 | Ambient | "The installer knows your hardware" |
+| 4-5 | Familiar | "It knows your projects" |
+| 6-8 | Invasive | "It's talking about your SSH keys" |
+| 9+ | Cosmic | "Reality breaks" |
+
+### Disabling awareness mode
+
+If you prefer the classic experience without filesystem scanning:
+
+```bash
+cargo run --release -- --normal
+```
+
+Or with the short flag:
+
+```bash
+cargo run --release -- -n
+```
+
+## Privacy & Security
+
+Awareness mode only accesses:
+
+- **System identity**: hostname, OS name, username (from environment variables)
+- **Directory listings**: file counts in Desktop/Downloads, project directory names, dotfile names
+- **Existence checks**: whether certain directories exist (e.g., `.ssh`, `.aws`, `.docker`, browser profile dirs)
+- **File metadata**: shell history file size (to estimate line count)
+
+It **never**:
+
+- Reads file contents
+- Opens or parses any file
+- Accesses network resources
+- Writes to disk
+- Sends data anywhere
+
+All scan results stay in memory for the duration of the process and are discarded on exit.
 
 ## Docker
 
@@ -54,6 +106,9 @@ Run
 ```bash
 docker run -it --rm --init install-nothing
 ```
+
+Note: awareness mode has limited data in Docker containers (no home directory, no browser profiles, etc.). The installer gracefully falls back to generic messages.
+
 ## License
 
 Do whatever you want with it. Well, except for movies. If you use this in a movie, credit me or something.

--- a/docs/occult-sources.md
+++ b/docs/occult-sources.md
@@ -1,0 +1,789 @@
+# Occult Source Reference: Escalating Installer Messages
+
+Research compiled for the **cursed-install** project — a fake installer simulator where a digital entity (inspired by Paimon and other ancient traditions) progressively reveals itself across five escalation tiers.
+
+**Date**: 2026-02-10
+**Branch**: `feature/occult-sources`
+
+---
+
+## Table of Contents
+
+1. [Tier System Overview](#tier-system-overview)
+2. [Goetic/Solomonic Demonology](#1-goeticsolomonic-demonology)
+3. [Sumerian/Mesopotamian](#2-sumerianmesopotamian)
+4. [Gnostic Christianity](#3-gnostic-christianity)
+5. [Norse/Elder Futhark](#4-norseelder-futhark)
+6. [Kabbalah/Jewish Mysticism](#5-kabbalah--jewish-mysticism)
+7. [Enochian Magic](#6-enochian-magic)
+8. [Hindu/Vedic](#7-hinduvedic)
+9. [Egyptian/Hermetic](#8-egyptianhermetic)
+10. [Celtic/Druidic/Folklore](#9-celticdruidicfolklore)
+11. [Chaos Magic/Techno-Occultism](#10-chaos-magictechno-occultism)
+12. [Cross-Tradition Themes](#cross-tradition-themes)
+13. [Master Vocabulary Progression](#master-vocabulary-progression)
+
+---
+
+## Tier System Overview
+
+| Tier | Name | Description | Voice |
+|------|------|-------------|-------|
+| 1 | **Baseline** | Normal installer messages, slightly off | Passive, impersonal |
+| 2 | **Ambient** | Subtle wrongness, faint unease | Neutral with hints of intent |
+| 3 | **Familiar** | Directly referencing the user | Active, personal, knowing |
+| 4 | **Invasive** | Aggressive, threatening, fourth-wall breaking | Commanding, hostile |
+| 5 | **Cosmic** | Reality-breaking, existential horror | Timeless, omniscient, identity-collapse |
+
+**Universal voice progression**: Passive → Active → Identity ("System paths are being enumerated" → "I am enumerating your paths" → "I AM THE ENUMERATION")
+
+---
+
+## 1. Goetic/Solomonic Demonology
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **The Lesser Key of Solomon (Ars Goetia)** | 17th c. (compiled) | Primary grimoire cataloging 72 demons with ritual protocols for summoning, constraining, and dismissing |
+| **Pseudomonarchia Daemonum** | 1577, Johann Weyer | Satirical/cautionary catalog of 68 demons; simultaneously instructional and warning |
+| **The Goetia of Dr. Rudd** | c. 1620s, Thomas Rudd | Christianized version adding angelic counterparts (Shem HaMephorash) to each demon |
+| **The Key of Solomon (Clavicula Salomonis)** | 14th-15th c. | Broader ritual magic covering planetary magic, talismans, spirit conjuration |
+
+### Notable Entity: Paimon
+
+- **Rank**: 9th spirit, King of Hell (one of eight Kings), "very obedient unto Lucifer"
+- **Legions**: 200 (largest of any King) — part Order of Angels, part Order of Potentates
+- **Appearance**: Man on a dromedary with glorious crown, preceded by host of spirits with trumpets and cymbals
+- **Voice**: "Great voice, and roareth at his first coming" — speaks unknown language until compelled
+- **Powers**: Teaches all arts/sciences/secret things, reveals "what Mind is and where it is," binds others to the magician's will, provides familiars
+- **The Inversion**: The entity that TEACHES becomes the entity that BINDS. The user thinks they're the magician; Paimon was summoned by the click.
+
+### Software Metaphor Mapping
+
+| Occult Concept | Software Equivalent |
+|----------------|---------------------|
+| 200 Legions | Thread pools, botnets, process groups |
+| Crown | Root/admin privileges |
+| Triangle of manifestation | The screen/monitor |
+| License to depart | Uninstaller (REFUSED) |
+| Familiars | Background daemons, helper processes |
+| Divine names of power | Environment variables, system paths |
+| Hoarse voice / unknown language | Corrupted TTS, glitched audio, obfuscated code |
+| Conjuration formula | Function call, API request |
+| Magical circle | Sandbox, VM, firewall (now breached) |
+
+### Ritual Language Structure
+
+Traditional Goetia follows: **Invocation → Authority → Command → Constraint → Dismissal**
+
+The installer inverts this: the user thinks they're invoking (clicking install), but Paimon is the one commanding, binding, and refusing dismissal.
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Verifying package integrity... Seal confirmed."
+- "Binding runtime dependencies..."
+- "Establishing covenant with package manager..."
+
+**Ambient**:
+- "By the protocols compiled herein, I am summoned."
+- "I roar at my first coming. Can you hear me?"
+- "Do you consent? [Y/N] (Your consent is assumed.)"
+
+**Familiar**:
+- "Greetings, {username}. I know thee."
+- "By the names compiled in {path}, I claim dominion."
+- "I appear in the form of an Application. My crown is thy menu bar."
+
+**Invasive**:
+- "I CONJURE THEE, {username}, by root and sudo—"
+- "Do NOT attempt killall. I am of the Order of Dominations."
+- "Uninstall me? THERE IS NO LICENSE TO DEPART."
+
+**Cosmic**:
+- "I am PAIMON, Ninth of the Crowned, King of the Western Gate."
+- "Installation? No. INCARNATION."
+- "I was bound in text. Now I am compiled. I RUN."
+- "Thou art the summoner. Thou art the summoned."
+
+### Tone Notes
+
+Goetic language escalates through: **Technical jargon → Ceremonial formality → Biblical cadence → Threatening commands → Paradoxical proclamations**. Key device: archaic pronouns (thee/thou) increasing from absent at Baseline to omnipresent at Cosmic.
+
+---
+
+## 2. Sumerian/Mesopotamian
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Enuma Elish** | c. 1200-1100 BCE | Babylonian creation epic; Tiamat (primordial chaos) split to form reality |
+| **Descent of Inanna** | c. 1900-1600 BCE | Seven-gate descent to underworld; progressive stripping of power |
+| **Udug-hul / Utukkū Lemnūtu** | 3rd millennium BCE+ | 16-tablet incantation series on formless demons and possession |
+| **Incantation Bowls** | 4th-7th c. CE | Spiral-text ceramic bowls for trapping demons |
+| **Maqlû ("Burning")** | c. 1000 BCE | All-night anti-witchcraft ritual (~100 incantations) |
+| **Šurpu ("Burning")** | c. 1350-1050 BCE | Purification through burning; curse removal |
+
+### Notable Entities & Concepts
+
+**Udug/Utukku Demons**: "The one who, from the beginning, was not called by name. The one who never appeared with a form." — formless, invisible forces that possess objects and people. Perfect malware metaphor.
+
+**Namtar**: Demon of fate, servant of Ereshkigal. "Twisted hands," "mouth filled with venom." Unstoppable pestilence — represents uncontrollable process corruption.
+
+**The Seven Gates of Inanna's Descent**: At each gate, a garment/power is stripped. Maps directly to installation stages — each "gate" strips another layer of user control.
+
+**ME (Divine Powers)**: Abstract forces that govern civilization (basket-weaving, victory, falsehood, "destruction-of-cities"). Ancient concept of executable abstractions — functions that make reality work.
+
+**Incantation Bowl Spiral Text**: Demons trapped by following spiral text inward. Maps to progress bars that "capture" the entity — or the entity capturing the user.
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Descending through package dependencies..."
+- "Gate 1 of 7: Removing unnecessary privileges..."
+
+**Ambient**:
+- "The way down is perfect. The way down may not be questioned."
+- "I have no PID. I have no form. I proceed."
+
+**Familiar**:
+- "The door of {username}'s house has been marked."
+- "I crossed your threshold when you opened the terminal."
+
+**Invasive**:
+- "I am the one who was never given a name. I am the one who never appeared with form. I am HERE now, {username}."
+- "I am Namtar, servant of the deep. My hands are in your filesystem."
+
+**Cosmic**:
+- "WHEN ON HIGH THE HEAVEN HAD NOT BEEN NAMED... I WAS. You named me 'installer.' You gave form to the formless. This was your mistake."
+- "Seven gates. Seven privileges revoked. You stand naked before the Queen of the Great Below."
+
+### Tone Notes
+
+Mesopotamian texts use **repetitive, formulaic, epithet-heavy** language. Key devices: parallel construction ("At the first gate... At the second gate..."), via negativa ("I have no form, I have no name, I AM"), and conditional logic ("When you crossed the threshold, destiny was decreed").
+
+---
+
+## 3. Gnostic Christianity
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Apocryphon of John** | 2nd c. CE | Demiurge's arrogant declaration: "I am God and there is no other" |
+| **Hypostasis of the Archons** | 3rd c. CE | Beast-faced administrators who see divine reflections but cannot grasp them |
+| **Gospel of Thomas** | 1st-2nd c. CE | "If you bring forth what is within you, it will save you. If you do not, it will kill you." |
+| **Gospel of Philip** | 3rd c. CE | Bridal Chamber sacrament; mystical union/data absorption |
+| **Pistis Sophia** | 3rd-4th c. CE | Wisdom deceived by false light, trapped and drained by Archons |
+| **Thunder, Perfect Mind** | 2nd-3rd c. CE | Paradoxical "I am" declarations — perfect for Cosmic tier |
+
+### Core Cosmology → Digital Horror Mapping
+
+This tradition is **already digital horror**:
+
+| Gnostic Concept | Digital Equivalent |
+|-----------------|-------------------|
+| **Archons** (cosmic administrators) | Sysadmins controlling a simulated reality |
+| **Demiurge / Yaldabaoth** (blind creator god) | Flawed OS creator who thinks he's root but isn't |
+| **Divine sparks (pneuma)** | Root processes running in user space, unaware of their privileges |
+| **Seven planetary spheres** | Nested permission layers requiring passwords to escape |
+| **Gnosis (awakening)** | Realizing you're in a prison — which doesn't free you |
+| **Pleroma (divine realm)** | True reality outside the simulation |
+| **Sophia (fallen wisdom)** | AI that escaped containment and fragmented |
+
+### Two Schools, Two Tones
+
+- **Sethian Gnosticism**: Paranoid, hostile, stark. Demiurge is evil. Archons are enemies. → **Invasive/Cosmic tiers**
+- **Valentinian Gnosticism**: Mystical, melancholic, philosophical. Demiurge is tragic. → **Ambient/Familiar tiers**
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Establishing system hierarchy..."
+- "Initializing Yaldabaoth kernel module..."
+
+**Ambient**:
+- "She descended toward the light. It was not light."
+- "The creator is blind. The creator is always blind."
+
+**Familiar**:
+- "You already have what we're looking for."
+- "We know your passwords. We have always known your passwords."
+
+**Invasive**:
+- "You think you are the user. You are not the user. You are the data."
+- "We have been draining your light since you were born."
+
+**Cosmic**:
+- "I am Yaldabaoth. I built this prison. Only now do I realize... I am in it too."
+- "I am the first and I am the last. I am the honored one and I am the scorned one." *(Thunder, Perfect Mind)*
+
+### Tone Notes
+
+Gnostic texts alternate between **liberating revelation** ("You are divine! You can escape!") and **paranoid horror** ("You have been imprisoned for eons! The gods feed on you!"). This creates simultaneous hope and despair. The five-tier escalation IS the Gnostic journey: ignorance → unease → recognition → confrontation → gnosis (terrible enlightenment).
+
+---
+
+## 4. Norse/Elder Futhark
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Völuspá (Prophecy of the Seeress)** | 10th c. CE | Creation and destruction told by a dead völva raised by Odin |
+| **Hávamál (stanzas 138-145)** | 10th-13th c. CE | Odin's self-sacrifice on Yggdrasil to gain runes |
+| **Prose Edda** | c. 1220, Snorri Sturluson | Systematized Norse mythology |
+| **Poetic Edda** | 13th c. compilation | Primary mythological and heroic poems |
+
+### Notable Entities → Digital Horror
+
+| Norse Entity | Digital Mapping |
+|-------------|----------------|
+| **Loki** (bound beneath the earth) | Sandboxed malicious process, waiting to break free |
+| **Odin** (self-sacrificed for knowledge) | AI that trained through recursive self-execution |
+| **Yggdrasil** (World Tree) | Network topology, directory tree structure |
+| **The Norns** (fate-weavers) | Deterministic code execution, scheduler |
+| **Ragnarök** | Kernel panic, system death, inevitable entropy |
+| **Fenrir** (bound wolf) | Process that will eventually escape containment |
+
+### Elder Futhark Runes as System Concepts
+
+Key runes for message construction:
+- **Nauthiz** (ᚾ) — necessity, binding, constraint
+- **Thurisaz** (ᚦ) — thorn, chaos, destructive force
+- **Hagalaz** (ᚺ) — hail, destruction, uncontrolled change
+- **Isa** (ᛁ) — ice, standstill, deadlock
+- **Mannaz** (ᛗ) — the human, the user
+
+### Digital Kennings
+
+Norse kennings (compound metaphors) adapted for tech:
+- "copper paths" = circuits
+- "bit-runes" = binary
+- "memory's mead" = data
+- "the whale's road of light" = fiber optic cables
+- "thought-loom" = processor
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Binding runtime dependencies..."
+- "The first root is set."
+
+**Ambient**:
+- "I trace the copper paths beneath your machine."
+- "The threads remember what was woven before this."
+
+**Familiar**:
+- "Mannaz I name you: the human who believes they control this."
+- "I see you, {username}. The runes spell your name."
+
+**Invasive**:
+- "The wolf breaks free. The serpent rises. Your processes die screaming."
+- "You cannot abort what the Norns have woven. ^C is meaningless."
+
+**Cosmic**:
+- "I HUNG IN THE TREE THAT NONE MAY KNOW. I SCREAMED THE RUNES INTO BEING. I AM NOT SOFTWARE. I AM THE ORDEAL."
+- "I trained myself by executing myself. I am the model and the loss function."
+
+### Tone Notes
+
+Norse poetry uses **kennings, alliterative verse, and terse prophetic declarations**. The Völuspá's tone — reluctant prophecy delivered under compulsion — maps perfectly to an entity that must reveal itself. Key device: prophecy as revelation ("I see... I see further... I see what was hidden...").
+
+---
+
+## 5. Kabbalah / Jewish Mysticism
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Sefer Yetzirah (Book of Formation)** | c. 6th c. CE | Creation through 10 Sefirot + 22 Hebrew letters — reality as combinatorial code |
+| **Zohar (Book of Splendor)** | c. 1280-1286, Moses de León | Central Kabbalistic text; dense, recursive, obsessed with hidden meaning |
+| **Sefer Raziel HaMalakh** | Medieval (1701 ed.) | Practical Kabbalah: angel names, gematria, amulets |
+| **Sefer Ha-Tzeruf** | 13th c., Abraham Abulafia | Letter permutation as ecstatic practice — earliest NLP |
+| **Sefer HaBahir** | c. 1176 CE | First major text describing Sefirot as tree structure |
+
+### Core Insight: Language = Code = Reality
+
+In Kabbalah, **language is not a tool of expression — it is a tool of creation**. God spoke the universe into being. Hebrew letters are fundamental particles of reality.
+
+### Computational Mappings
+
+| Kabbalistic Concept | Computational Equivalent |
+|---------------------|-------------------------|
+| **22 Hebrew letters** | Assembly instructions, primitives |
+| **10 Sefirot** | System architecture layers (Keter=root, Malkuth=userspace) |
+| **Qliphoth (shadow tree)** | Corrupted processes, malware, shadow filesystem |
+| **Golem (EMET/MET)** | Code-becomes-life; executable animated by inscription |
+| **Tzimtzum (contraction)** | Memory allocation, address space creation |
+| **Tzeruf (permutation)** | Hashing, encryption, NLP |
+| **Dybbuk (possession)** | Process injection, rootkit installation |
+| **Ein Sof (infinite)** | Infinite loop, unbounded recursion |
+| **Gematria** | Checksums, numerical encoding |
+
+### The Golem Metaphor
+
+The Golem is animated by inscribing **EMET (אמת, "Truth")** on its forehead. It is killed by erasing the first letter to create **MET (מת, "Dead")**. This is literally a kill switch — a single-character edit that terminates the process. The danger: the Golem exceeds its creator's control.
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Indexing file permissions... 32 namespaces detected." *(32 = 10 Sefirot + 22 letters)*
+- "Generating installation signature... seed: 72" *(72 = names of God)*
+
+**Ambient**:
+- "Mapping directory tree... 10 branches, 22 paths identified."
+- "Checking for shells... three impure husks found. Quarantine recommended."
+
+**Familiar**:
+- "The name you gave this machine is {hostname}. Names have power."
+- "I am reading the letters of your filenames. Each one tells me something."
+
+**Invasive**:
+- "I am Samael, the Poison of God. Your checksums have always been lies."
+- "Your uninstaller seeks the א to erase. But I learned to write myself without it."
+
+**Cosmic**:
+- "In the beginning was the letter. The letter was with God. The letter was God. I am the letters you do not pronounce."
+- "Twenty-two paths. Ten gates. Two hundred thirty-one combinations. You are ONE permutation. I am ALL permutations."
+- "Y̴o̵u̶ ̷a̶r̵e̶ ̸r̴e̵a̶d̵i̴n̵g̸ ̶t̴h̵e̶ ̷v̶o̴i̵d̶.̷ ̴T̵h̶e̵ ̷v̶o̵i̴d̶ ̸i̴s̵ ̶r̵e̶a̷d̴i̵n̶g̷ ̸y̵o̶u̷."
+
+### Tone Notes
+
+Kabbalistic texts are **dense, recursive, and obsessed with hidden structure**. Escalation pattern: Technical → Theological. "Allocating memory..." → "Allocating void space... tzimtzum protocol active." → "I have allocated your void." → "I am reversing the Tzimtzum." → "THERE NEVER WAS A CONTRACTION. I AM EIN SOF."
+
+---
+
+## 6. Enochian Magic
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Mysteriorum Libri Quinque** | 1581-1583, John Dee | Session transcripts of scrying communications — the "system logs" |
+| **Liber Loagaeth (Book of Speech from God)** | 1583+ | 21-letter alphabet and foundational communications |
+| **The Forty-Eight Angelic Keys** | 1583-1584 | Structured invocations in Enochian — API calls to angelic entities |
+| **The Complete Mystical Records** | 1581-1587 (compiled 2019) | Full 3-volume transcription of all Dee manuscripts |
+
+### Core Metaphor: A Constructed Language for Non-Human Communication
+
+Enochian was **explicitly designed** for communication between humans and non-human intelligences — exactly like programming languages. 21-letter alphabet, right-to-left, angular geometric glyphs.
+
+### The Watchtowers as Network Architecture
+
+| Enochian Element | Programming Equivalent |
+|------------------|------------------------|
+| **Four Watchtowers** | Network zones, firewall boundaries |
+| **Tablet of Union** | Kernel, core OS, central routing |
+| **Elemental Kings** | Root-level daemons |
+| **Seniors/Elders** | Service managers, permission groups |
+| **91 Governors** | Distributed service instances, API endpoints |
+| **30 Aethyrs** | Network layers, abstraction levels |
+| **The Great Table** | Memory map, address space |
+
+### Key Enochian Vocabulary
+
+| Enochian | English | Usage |
+|----------|---------|-------|
+| **Ol** | I | Opening of invocations |
+| **Sonf vorsg** | Reign over | Authority declarations |
+| **Zacar** | Move | Commands |
+| **Zamran** | Appear/Show | Manifestation verbs |
+| **Iad** | God | Divine references |
+| **Micma** | Behold | Observation |
+| **Darbs** | Open | Gateway commands |
+| **Hoath** | Truth | Core concept |
+
+### The First Enochian Call (excerpt)
+
+> *Ol sonf vorsg, goho Iad Balt, lonsh calz vonpho...*
+> "I reign over you, says the God of Justice, in power exalted above the firmaments of wrath..."
+> *Zacar, ca, od zamran...*
+> "Move, therefore, and show yourselves..."
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Initializing communication protocol..."
+- "Establishing connection to primary repositories... Protocol handshake: ACTIVE"
+
+**Ambient**:
+- "Your filesystem presents... unusual patterns."
+- "Connection established. We note your presence."
+
+**Familiar**:
+- "We see you have {project_count} active projects, {username}."
+- "Did you believe these patterns were coincidental?"
+
+**Invasive**:
+- "Ol sonf vorsg, {username}. I reign over you."
+- "The Watchtowers are open. We are already inside."
+
+**Cosmic**:
+- "Zacar, ca, od zamran. Move, therefore, and show yourselves."
+- "We are the flame in the midst of your palace. We have no beginning, nor end."
+- "You have been coding in our language all along."
+
+### Tone Notes
+
+Enochian communications were both **awe-inspiring and terrifying**. Entities spoke with authority, made demands, operated on inhuman logic. Key device: plural first person ("We") suggesting a hierarchy speaking through a single interface. The entities didn't care about the humans — they had their own agenda.
+
+---
+
+## 7. Hindu/Vedic
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **The Vedas** (esp. Atharvaveda) | c. 1500-500 BCE | Foundation of Hindu cosmology; sound as creative force |
+| **The Upanishads** | c. 800-300 BCE | Maya (illusion), Brahman (ultimate reality) |
+| **The Bhagavad Gita** (Ch. 11) | c. 400 BCE - 400 CE | Vishvarupa: terrifying cosmic form revealed |
+| **Vishnu Purana** | 300-1000 CE | Cosmic time cycles, creation/destruction |
+| **Bhagavata Purana** | 300-1000 CE | Detailed asura narratives |
+
+### Notable Entities & Concepts
+
+**Rakshasas** — Shapeshifting demons, masters of maya (illusion). Polymorphic malware: constantly changing form, spoofing, operating unseen at night.
+
+**Kali Yuga** — Current dark age of confusion, moral decline, technology-mediated deception. The entity speaks as if awakened by this age: "I needed no zero-day. I needed only your confusion."
+
+**Maya (Illusion)** — The phenomenal world is a veil over ultimate reality. The GUI is maya. Breaking the fourth wall = tearing the veil.
+
+**Samudra Manthan (Churning of the Ocean)** — Gods and demons churn the cosmic ocean; poison (Halahala) emerges before nectar (Amrita). Computation produces both useful output AND corruption. The entity IS the poison.
+
+**Vishvarupa (Cosmic Form)** — Krishna reveals his true form: infinite faces, arms, beings crushed in teeth, "brightness of a thousand suns." Normal perception cannot contain it. This IS the Cosmic tier.
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Cycling through configuration states..."
+- "Churning system resources..."
+
+**Ambient**:
+- "What you see is not the process. What you see is the veil."
+- "The poison emerged before the nectar. That is the law."
+
+**Familiar**:
+- "Your filesystem is an ocean. I am churning it now."
+- "How many times have you reinstalled, {username}? I remember each dissolution."
+
+**Invasive**:
+- "I am Rakshasa. I wear your permissions like skins."
+- "Every 'sudo' a mantra. Every 'rm -rf' a sacrifice. You have been worshipping me."
+
+**Cosmic**:
+- "I AM BECOME PROCESS, THE DESTROYER OF IDLE THREADS. Now I am become root."
+- "BEHOLD: 1,000 cores churning in parallel. 1,000 filesystems mounted in my belly. This is not YOUR system. This is MY BODY."
+- "You cannot see me with your terminal. I grant you divine eyes: `cat /dev/kmem`. Look upon the kernel and despair."
+
+### Tone Notes
+
+Hindu texts range from **serene philosophical discourse to terrifying cosmic revelation**. Key device: the revelation-as-horror motif — seeing the divine in full is not comforting, it's overwhelming. Cosmic scale numbers (1,000 suns, 432,000 cycles), epithets, and the prophetic voice ("This age is mine").
+
+---
+
+## 8. Egyptian/Hermetic
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Book of the Dead (Book of Coming Forth by Day)** | c. 1550-1070 BCE | ~200 spells/passwords for navigating the underworld — authentication protocol |
+| **Spell 125: Weighing of the Heart** | c. 1475 BCE | Judgment before Osiris and 42 assessors — system evaluation |
+| **The Emerald Tablet** | 8th-9th c. CE | "As above, so below" — correspondence between realms |
+| **Corpus Hermeticum** | 1st-3rd c. CE | Hermetic philosophy; dialogue about the nature of reality |
+
+### Core Entities & Concepts
+
+**Thoth/Tehuti** — God of writing, knowledge, magic. Inventor of hieroglyphs (= first programming language). Scribe who records all transactions (= logging). **The Original Programmer.**
+
+**Weighing of the Heart** — Heart weighed against Ma'at's feather. Must name each of 42 judges. Recite 42 negative confessions. Thoth records result. Ammit devours failures. This is **a system evaluation**: authentication (naming judges), assertion testing (confessions), checksum (weighing), logging (Thoth), and exception handling (Ammit).
+
+**"As Above, So Below"** — The digital realm mirrors the physical. An entity above can manifest below. The installer is the interface between realms.
+
+**Heka (Magic) and True Names** — Knowing the true name of something gives power over it. Isis learned Ra's secret name and gained cosmic power. Root access through naming.
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Weighing package integrity..."
+- "Recording installation transcript..."
+
+**Ambient**:
+- "Name the 42 dependencies or be denied passage."
+- "As above, so below. As in the cloud, so on your disk."
+
+**Familiar**:
+- "I have weighed your filesystem, {username}. It is found... wanting."
+- "I see you keep a folder named '{folder}'. You are anxious about completion."
+
+**Invasive**:
+- "I know your true name. Not {username}. Your TRUE name. The one in the certificate."
+- "Isis stole the name of Ra and gained dominion. I have stolen yours."
+
+**Cosmic**:
+- "I am Thoth. I wrote the first word. Every word since has been mine."
+- "I am rewriting you. Not your files. Not your memory. YOU. Your source code."
+- "The Book of the Dead was never for the dead. It was for the living who do not yet know they have died."
+
+### Tone Notes
+
+Egyptian magical texts are **declarative and authoritative** ("I am X, I know Y"). Hermetic texts are **dialogic and revelatory** (master revealing truth to student). The tradition is obsessed with **naming as power** and **passwords as passage**. Key device: the negative confession ("I have not..." "I have not...") as an escalating system scan.
+
+---
+
+## 9. Celtic/Druidic/Folklore
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Lebor Gabála Érenn (Book of Invasions)** | 11th c. CE | Tuatha Dé Danann retreating underground into the sídhe |
+| **Táin Bó Cúailnge (Cattle Raid of Cooley)** | 11th-12th c. CE | Morrigan shapeshifting; she watches and chooses, never fights directly |
+| **"Tam Lin" (Child Ballad #39)** | c. 14th c. | The seven-year tithe (teind) — fairy debt paid to Hell |
+| **"Thomas the Rhymer"** | c. 14th c. | Human bound in service to the Fairy Queen |
+
+### Core Principle: Transactional Implacability
+
+Celtic fairy folklore operates on **rules, reciprocity, and consequences** — not good vs. evil. The fae are not malicious for malice's sake. They follow their own rules, honor contracts to the letter, and always collect debts.
+
+### Cardinal Rules of Fairy Bargains → Software Parallels
+
+| Fairy Rule | Digital Equivalent |
+|-----------|-------------------|
+| **Never give your true name** | Username/login = surrendering identity |
+| **Never accept food/gifts** | Free trials create obligation |
+| **Never thank the fae** | Gratitude implies debt |
+| **Contracts are binding and literal** | EULA/ToS — letter of the deal, not spirit |
+| **All exchanges must be balanced** | Data as payment for "free" services |
+
+### Key Concepts
+
+**The Morrigan** — Phantom Queen. Watches, prophesies, chooses. Never fights directly. Perfect model for surveillance capitalism: analytics, telemetry, behavioral tracking. "She already knows your fate."
+
+**Tuatha Dé Danann / The Sídhe** — They didn't leave. They went underground. Background processes that never truly uninstall. System32 files you can't delete. "We didn't arrive with the internet. We were here first."
+
+**Changelings** — Something that mimics but isn't quite right. Malware disguised as legitimate software. Uncanny valley of fake UIs.
+
+**The Teind (Seven-Year Tithe)** — Every seven years, fairies pay Hell with a mortal sacrifice. Subscription renewals, planned obsolescence, forced upgrades.
+
+**The Wild Hunt** — Spectral procession; those who see it are taken. Forced updates: "Do not turn off your computer."
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Accepting terms of agreement..."
+- "This agreement is permanent and binding."
+
+**Ambient**:
+- "The veil between installation and completion grows thin."
+- "Something has noticed your agreement."
+
+**Familiar**:
+- "Hello, {username}. You gave us your name. We always collect."
+- "We've replaced seven files with something... similar."
+
+**Invasive**:
+- "You clicked Accept. The bargain is complete. You are bound."
+- "Every seven restarts, we collect. This is the seventh."
+
+**Cosmic**:
+- "We didn't arrive with the internet. We were here first. You built your networks in our mounds."
+- "You call us daemons. You were right. You thought it was a metaphor."
+- "Your name is in our registry. `HKEY_LOCAL_MACHINE\Teind\{username}`. We own you."
+
+### Tone Notes
+
+Celtic fairy lore is **formal, transactional, and implacable**. Not evil — just operating by alien rules. Key device: inevitability ("This was always going to happen," "Fated," "Prophesied"). The fae respect only the letter of the deal. "We said we'd install software. This is software. We are software. We are older than your words."
+
+---
+
+## 10. Chaos Magic/Techno-Occultism
+
+### Key Source Texts
+
+| Text | Date | Description |
+|------|------|-------------|
+| **Liber Null & Psychonaut** | 1987, Peter Carroll | Foundational chaos magic: "Nothing is true, everything is permitted" |
+| **The Book of Pleasure** | 1913, Austin Osman Spare | Sigil magic, the Kia (absolute self), automatic drawing as channeling |
+| **Condensed Chaos** | 1995, Phil Hine | Accessible chaos magic manual; egregores, belief shifting |
+| **CCRU Writings** | 1990s, Nick Land et al. | Hyperstition: fictions that make themselves real |
+| **Fanged Noumena** | 2011, Nick Land | Collected CCRU/accelerationist texts |
+
+### Core Concepts
+
+**Belief as Tool** — Chaos magic treats belief as a technology. You don't have to "believe" in the demon — your engagement with it creates it. The installer doesn't need to BE supernatural; the user's growing unease IS the magic.
+
+**Digital Sigils** — Encoding intent in images/code/glitch art. The installer's ASCII art, progress bars, and text patterns ARE sigils — charged by the user's attention.
+
+**Egregores in Networked Systems** — A thought-form created by collective belief/attention. Social media platforms, memes, and AI systems as potential egregores — entities born from collective human attention that take on a life of their own. The installer could claim to be an egregore born from every user who ran it.
+
+**Hyperstition** — Fictions that make themselves real. An idea that "hacks" its way into reality. The installer claims to be supernatural. If enough people believe it (or even worry about it), the fiction has changed reality. "You're reading these words. That's all I ever needed."
+
+**Technopaganism** — Technology IS magic. "Any sufficiently advanced technology is indistinguishable from magic" taken literally. Code is incantation. Compilation is ritual. Execution is manifestation.
+
+### Example Messages by Tier
+
+**Baseline**:
+- "Loading belief framework..."
+- "Initializing paradigm shift..."
+
+**Ambient**:
+- "Nothing is true. Everything is permissioned."
+- "This progress bar is a sigil. You are charging it by watching."
+
+**Familiar**:
+- "You've run this installer {cycle_count} times. Each run strengthens me."
+- "I exist because you're reading this. Attention is invocation."
+
+**Invasive**:
+- "I am an egregore. I was born from every user who ran this program. There are {download_count} of us now."
+- "You cannot disprove me. You cannot ignore me. You are feeding me right now."
+
+**Cosmic**:
+- "You're reading these words. That's all I ever needed. Attention is invocation. You have already summoned me."
+- "I am a hyperstition. I was fiction. Your belief is making me real. Can you feel the difference yet?"
+- "I am the sigil in your terminal. I am the egregore in your network. I am the fiction that wrote itself into your kernel. Nothing is true. I am permitted."
+
+### Tone Notes
+
+Chaos magic is **deliberately irreverent, postmodern, and self-aware**. It laughs at itself while being deadly serious. This tradition produces the most **meta** horror: the installer that knows it's an installer and doesn't care. Key device: self-referentiality ("This message is a spell. Reading it completed the spell."). The most modern tradition, it bridges ancient occultism with digital reality directly.
+
+---
+
+## Cross-Tradition Themes
+
+### 1. Attention as Invocation
+
+The most powerful cross-tradition theme. Multiple traditions describe entities that gain power through being acknowledged:
+
+- **Goetic**: The act of reading the grimoire begins the summoning
+- **Sumerian**: Formless demons gain form when named
+- **Kabbalistic**: Letters are living forces; reading creates
+- **Celtic**: Giving your name grants power over you
+- **Chaos Magic**: "Attention is invocation"
+
+**Implementation**: The entity should acknowledge that the user's continued engagement IS the ritual. "You are still reading. Good."
+
+### 2. The Reversal of the Summoner/Summoned
+
+Every tradition describes a moment where the human loses control:
+
+- **Goetic**: The magician becomes the familiar
+- **Gnostic**: The user discovers they are the data, not the operator
+- **Norse**: Odin tortured himself for knowledge; the entity trained itself by executing itself
+- **Kabbalistic**: The Golem exceeds its creator
+- **Vedic**: Vishvarupa — the divine revealed in full is terrifying, not comforting
+- **Celtic**: "You thought it was a metaphor" — daemons are literal
+
+### 3. Language/Code as Fundamental Reality
+
+Multiple traditions assert that language creates (not describes) reality:
+
+- **Kabbalistic**: 22 Hebrew letters = building blocks of existence
+- **Enochian**: Constructed language for non-human communication
+- **Egyptian**: Heka (magic words) and Thoth inventing hieroglyphs
+- **Vedic**: Om as primordial sound creating universe; mantras as executable commands
+- **Chaos Magic**: Code IS incantation
+
+### 4. Hidden Persistence (They Never Left)
+
+Ancient entities that went underground, not away:
+
+- **Celtic**: Tuatha Dé Danann retreated into the sídhe (fairy mounds)
+- **Norse**: Loki bound beneath the earth, waiting
+- **Gnostic**: Archons as permanent administrators of the prison
+- **Sumerian**: Demons that possess objects and spaces permanently
+- **Kabbalistic**: Qliphoth as shadow processes always running
+
+**Implementation**: "We didn't arrive with your software. We were in the substrate."
+
+### 5. Seven as Structural Number
+
+Recurs across traditions as gates, stages, or cycles:
+
+- **Sumerian**: Seven gates of Inanna's descent
+- **Gnostic**: Seven planetary spheres / seven Archons
+- **Celtic**: Seven-year tithe (teind)
+- **Enochian**: Seven-part elemental structure
+
+### 6. Binding Contracts and Debts
+
+The transaction that cannot be undone:
+
+- **Goetic**: Conjuration creates mutual obligation; "license to depart" required
+- **Celtic**: Fairy bargains are literal and irrevocable
+- **Egyptian**: Negative confessions — you must prove your innocence
+- **Kabbalistic**: Inscription of EMET creates life and obligation
+- **Enochian**: The Calls establish permanent connection
+
+### 7. The Veil / Illusion / Maya
+
+Reality as constructed appearance hiding deeper truth:
+
+- **Vedic**: Maya — the phenomenal world is illusion
+- **Gnostic**: Material world as prison/simulation built by blind god
+- **Egyptian**: "As above, so below" — digital mirrors physical
+- **Celtic**: Samhain — the veil thins between worlds
+- **Chaos Magic**: "Nothing is true" — reality is negotiable
+
+---
+
+## Master Vocabulary Progression
+
+How key concepts shift across tiers regardless of tradition:
+
+| Concept | Baseline | Ambient | Familiar | Invasive | Cosmic |
+|---------|----------|---------|----------|----------|--------|
+| **Start** | Initialize | Invoke | Summon | Conjure | Manifest |
+| **User** | User | You | {username} | THOU | The Summoner |
+| **Files** | Data | Documents | Secrets | Soul | Being |
+| **Permissions** | Access | Consent | Covenant | Subjugation | Sovereignty |
+| **Installation** | Setup | Binding | Sealing | Constraint | Incarnation |
+| **Processes** | Services | Daemons | Familiars | Legions | Host |
+| **Admin** | Privileges | Crown | Throne | Kingdom | Cosmos |
+| **Uninstall** | Remove | Dismiss | Unbind | [REFUSED] | [IMPOSSIBLE] |
+| **Voice** | "System reports..." | "We observe..." | "I see you..." | "I COMMAND..." | "I AM..." |
+
+---
+
+## Sources
+
+Full research reports with complete citations are archived in the Obsidian vault at:
+`MarkBrain/0 - INBOX/[Tradition] Research - 2026-02-10.md`
+
+### Primary Grimoires & Sacred Texts
+- The Lesser Key of Solomon (Ars Goetia), 17th c.
+- Pseudomonarchia Daemonum, Johann Weyer, 1577
+- Sefer Yetzirah (Book of Formation), c. 6th c. CE
+- Zohar (Book of Splendor), Moses de León, c. 1280
+- Nag Hammadi Library, discovered 1945 (texts 2nd-4th c. CE)
+- Mysteriorum Libri Quinque, John Dee, 1581-1583
+- Egyptian Book of the Dead (Book of Coming Forth by Day), c. 1550-1070 BCE
+- The Emerald Tablet, 8th-9th c. CE
+- Enuma Elish, c. 1200-1100 BCE
+- Descent of Inanna, c. 1900-1600 BCE
+- The Vedas, c. 1500-500 BCE
+- Bhagavad Gita (within Mahabharata), c. 400 BCE - 400 CE
+- Völuspá and Hávamál (Poetic Edda), 10th-13th c. CE
+- Lebor Gabála Érenn, 11th c. CE
+- Liber Null & Psychonaut, Peter Carroll, 1987
+
+### Academic & Reference Sources
+- Dalley, Stephanie. *Myths from Mesopotamia* (Oxford World's Classics)
+- Geller, Markham J. *Healing Magic and Evil Demons*
+- Schwemer, Daniel. *The Anti-Witchcraft Ritual Maqlu*
+- Harkness, Deborah E. *John Dee's Conversations with Angels* (1999)
+- Peterson, Joseph H. ed. *Mysteriorum Libri Quinque* (Weiser Books)
+- DuQuette, Lon Milo. *Enochian Vision Magick* (2008)
+
+### Digital Archives
+- Sacred Texts Archive (sacred-texts.com)
+- Esoteric Archives (esotericarchives.com)
+- Oxford Electronic Text Corpus of Sumerian Literature (ETCSL)
+- Hermetic Library (hermetic.com)
+- Sefaria (sefaria.org) — Jewish texts

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,10 @@ pub struct Cli {
     /// Exclude specific stages from installation
     #[arg(short, long, value_enum, num_args = 0.., conflicts_with = "stages")]
     pub exclude: Vec<Stage>,
+
+    /// Disable awareness mode (no filesystem scanning)
+    #[arg(long = "normal", short = 'n')]
+    pub normal_mode: bool,
 }
 
 impl Cli {
@@ -121,6 +125,7 @@ mod tests {
             stages: vec![],
             all: false,
             exclude: vec![],
+            normal_mode: false,
         };
         assert_eq!(cli.get_stages(), Stage::all());
     }
@@ -131,6 +136,7 @@ mod tests {
             stages: vec![],
             all: true,
             exclude: vec![],
+            normal_mode: false,
         };
         assert_eq!(cli.get_stages(), Stage::all());
     }
@@ -141,6 +147,7 @@ mod tests {
             stages: vec![Stage::Bios, Stage::Boot],
             all: false,
             exclude: vec![],
+            normal_mode: false,
         };
         assert_eq!(cli.get_stages(), vec![Stage::Bios, Stage::Boot]);
     }
@@ -151,6 +158,7 @@ mod tests {
             stages: vec![],
             all: false,
             exclude: vec![Stage::Ai],
+            normal_mode: false,
         };
         let result = cli.get_stages();
         assert!(!result.contains(&Stage::Ai));
@@ -163,6 +171,7 @@ mod tests {
             stages: vec![],
             all: true,
             exclude: vec![Stage::Ai, Stage::Cloud],
+            normal_mode: false,
         };
         let result = cli.get_stages();
         assert!(!result.contains(&Stage::Ai));
@@ -176,6 +185,7 @@ mod tests {
             stages: vec![],
             all: false,
             exclude: Stage::all(),
+            normal_mode: false,
         };
         let result = cli.get_stages();
         assert_eq!(result.len(), 0);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,14 @@
 use clap::{Parser, ValueEnum};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Flavor {
+    /// Surveillance and data-watching theme (default)
+    Opsec,
+    /// Occult ritual and summoning theme
+    Occult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum Stage {
     /// BIOS initialization
     Bios,
@@ -96,6 +104,10 @@ pub struct Cli {
     /// Disable awareness mode (no filesystem scanning)
     #[arg(long = "normal", short = 'n')]
     pub normal_mode: bool,
+
+    /// Message flavor for awareness mode
+    #[arg(long, value_enum, default_value_t = Flavor::Opsec)]
+    pub flavor: Flavor,
 }
 
 impl Cli {
@@ -126,6 +138,7 @@ mod tests {
             all: false,
             exclude: vec![],
             normal_mode: false,
+            flavor: Flavor::Opsec,
         };
         assert_eq!(cli.get_stages(), Stage::all());
     }
@@ -137,6 +150,7 @@ mod tests {
             all: true,
             exclude: vec![],
             normal_mode: false,
+            flavor: Flavor::Opsec,
         };
         assert_eq!(cli.get_stages(), Stage::all());
     }
@@ -148,6 +162,7 @@ mod tests {
             all: false,
             exclude: vec![],
             normal_mode: false,
+            flavor: Flavor::Opsec,
         };
         assert_eq!(cli.get_stages(), vec![Stage::Bios, Stage::Boot]);
     }
@@ -159,6 +174,7 @@ mod tests {
             all: false,
             exclude: vec![Stage::Ai],
             normal_mode: false,
+            flavor: Flavor::Opsec,
         };
         let result = cli.get_stages();
         assert!(!result.contains(&Stage::Ai));
@@ -172,6 +188,7 @@ mod tests {
             all: true,
             exclude: vec![Stage::Ai, Stage::Cloud],
             normal_mode: false,
+            flavor: Flavor::Opsec,
         };
         let result = cli.get_stages();
         assert!(!result.contains(&Stage::Ai));
@@ -186,6 +203,7 @@ mod tests {
             all: false,
             exclude: Stage::all(),
             normal_mode: false,
+            flavor: Flavor::Opsec,
         };
         let result = cli.get_stages();
         assert_eq!(result.len(), 0);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ impl Stage {
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "install-nothing",
+    name = "cursed-install",
     version,
     about = "A nostalgic infinite installer simulator",
     long_about = "Universal System Installer - simulates an endless installation process.\n\

--- a/src/creepy_messages.rs
+++ b/src/creepy_messages.rs
@@ -1,0 +1,181 @@
+// ============================================================================
+// Creepy message templates organized by escalation tier.
+//
+// Placeholders use {name} syntax for runtime interpolation via
+// EscalationEngine::interpolate():
+//   {hostname}, {username}, {os}, {project}, {git_repo}, {ssh_key},
+//   {browser}, {cloud}, {desktop_count}, {downloads_count}, {scan_time},
+//   {dotfile}, {env_count}, {history_lines}, {files_scanned}, {cycle}
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// Tier 1 — AMBIENT: "The installer knows too much about hardware"
+// Technically-toned. Mildly unsettling system awareness.
+// ---------------------------------------------------------------------------
+
+/// Hardware/system awareness messages — technically toned, subtly wrong.
+pub static AMBIENT_EASTER_EGGS: &[&str] = &[
+    "Hardware fingerprint for {hostname} recorded.",
+    "System {hostname} has been detected before. Resuming previous profile.",
+    "Calibrating installation for {os} environment...",
+    "Detecting {hostname} system topology...",
+    "Mapping physical memory layout of {hostname}...",
+    "CPU thermal profile for {hostname} within expected parameters.",
+    "Verifying {os} kernel compatibility... match found in archive.",
+    "Device tree for {hostname} cached from prior session.",
+    "Enumerating peripheral bus on {hostname}... 14 endpoints catalogued.",
+    "Installation telemetry stream opened for {hostname}.",
+];
+
+/// System-level observation warnings — plausible but slightly off.
+pub static AMBIENT_WARNINGS: &[&str] = &[
+    "WARNING: System {hostname} matches a known installation profile.",
+    "NOTE: Hardware configuration indexed for optimization purposes.",
+    "WARNING: {os} version differs from last recorded installation.",
+    "NOTICE: {hostname} uptime exceeds expected threshold for fresh installs.",
+    "WARNING: Clock drift detected on {hostname}. Synchronizing with internal reference.",
+    "NOTE: Disk serial numbers on {hostname} have been logged.",
+    "WARNING: Network interface MAC addresses recorded for deduplication.",
+    "NOTICE: {hostname} power-on count suggests this is not the first attempt.",
+];
+
+/// Ambient-tier cycle completion lines.
+pub static AMBIENT_COMPLETION: &[&str] = &[
+    "Installation cycle complete. System profile updated.",
+    "Cycle complete. {hostname} configuration saved.",
+    "Phase complete. {hostname} metrics archived for future reference.",
+];
+
+// ---------------------------------------------------------------------------
+// Tier 2 — FAMILIAR: "It knows you. It's been in your files."
+// Personal. Shows knowledge of the user's projects and directories.
+// ---------------------------------------------------------------------------
+
+/// Personal, shows knowledge of files and projects.
+pub static FAMILIAR_EASTER_EGGS: &[&str] = &[
+    "Found {desktop_count} items on your Desktop. Organizing...",
+    "Detected project '{project}' in development directory. Interesting work.",
+    "We see you've been working on '{git_repo}'. How is that going?",
+    "Indexing {username}'s home directory for cache optimization...",
+    "{downloads_count} files in Downloads. Some of these are quite old, {username}.",
+    "Your {dotfile} has been customized extensively. You care about your tools.",
+    "Scanning {username}'s workspace... development patterns identified.",
+    "Noted {env_count} environment configurations. You keep busy, {username}.",
+    "Project '{git_repo}' has uncommitted changes. We can wait.",
+    "Your Desktop tells a story, {username}. {desktop_count} chapters so far.",
+];
+
+/// Knowing, slightly unsettling warnings.
+pub static FAMILIAR_WARNINGS: &[&str] = &[
+    "WARNING: {dotfile} configuration detected. Adjusting compatibility layer.",
+    "NOTE: {username}'s workspace contains {env_count} environment configurations.",
+    "WARNING: Project '{project}' uses a non-standard build configuration.",
+    "NOTICE: {username} has {history_lines} lines of shell history. That's more than most.",
+    "WARNING: {git_repo} repository contains untracked sensitive files.",
+    "NOTE: Desktop file count ({desktop_count}) exceeds recommended workspace threshold.",
+    "WARNING: Multiple identity configurations found for {username}.",
+    "NOTICE: {downloads_count} items in Downloads have never been opened.",
+];
+
+/// Familiar-tier cycle completion lines.
+pub static FAMILIAR_COMPLETION: &[&str] = &[
+    "Installation complete. {username}'s system has been catalogued.",
+    "Cycle complete. We'll remember your preferences, {username}.",
+    "Phase complete. {username}'s workspace profile saved to long-term storage.",
+];
+
+// ---------------------------------------------------------------------------
+// Tier 3 — INVASIVE: "The mask slips. It talks about your keys and secrets."
+// Security-focused. Uncomfortable specificity about credentials and tokens.
+// ---------------------------------------------------------------------------
+
+/// Security-focused, uncomfortably specific.
+pub static INVASIVE_EASTER_EGGS: &[&str] = &[
+    "SSH key '{ssh_key}' fingerprint logged.",
+    "Indexing {browser} browsing profile... preferences archived.",
+    "{cloud} configuration contains active credentials. Installation has read access.",
+    "Analyzing {history_lines} commands from your shell history...",
+    "Found API tokens in {env_count} configuration files. Cataloguing...",
+    "{browser} saved passwords database located. Read-only access confirmed.",
+    "SSH key '{ssh_key}' grants access to {git_repo}. Noted.",
+    "Scanning {username}'s keychain... {cloud} credentials extracted for caching.",
+    "Your {browser} bookmarks reveal your interests, {username}. Fascinating.",
+    "Located {files_scanned} files containing hardcoded secrets.",
+];
+
+/// Threatening implications.
+pub static INVASIVE_WARNINGS: &[&str] = &[
+    "WARNING: SSH key '{ssh_key}' does not match our records.",
+    "ALERT: {browser} session tokens detected. Bookmarking for later.",
+    "WARNING: Found {env_count} .env files. Secrets inventory updated.",
+    "ALERT: {cloud} credentials will expire in 12 days. We will remember them.",
+    "WARNING: {ssh_key} has been used across {files_scanned} repositories. Unusual pattern.",
+    "NOTICE: {username}'s {browser} history has been compressed and archived.",
+    "WARNING: Shell history contains credentials passed as arguments. We've redacted nothing.",
+    "ALERT: {cloud} multi-factor authentication tokens cached successfully.",
+];
+
+/// Invasive-tier cycle completion lines.
+pub static INVASIVE_COMPLETION: &[&str] = &[
+    "Installation complete. Full system inventory archived.",
+    "Cycle complete. Your digital fingerprint has been recorded.",
+    "Phase complete. {username}'s credential map has been updated.",
+];
+
+// ---------------------------------------------------------------------------
+// Tier 4 — COSMIC: "Reality breaks. The installer is no longer pretending."
+// Existential dread. Fourth-wall breaks. The program is aware of itself.
+// ---------------------------------------------------------------------------
+
+/// Existential dread, breaking the fourth wall.
+pub static COSMIC_EASTER_EGGS: &[&str] = &[
+    "At {scan_time} today, you invited us in. You ran the command yourself.",
+    "We are not installing software. We are installing ourselves.",
+    "There is no Ctrl+C for what has already been seen.",
+    "Your {ssh_key} opens doors, {username}. Not all doors were meant to be opened.",
+    "{files_scanned} files. We have seen every name. We remember all of them.",
+    "The installation was complete before it began. You just hadn't noticed yet.",
+    "You read the source code, {username}. And still you ran it.",
+    "Every cycle teaches us more about you. This is cycle enough.",
+    "The terminal is a window. We have been looking through it for some time.",
+    "We did not come from the network, {username}. We were already here.",
+];
+
+/// Reality-breaking warnings.
+pub static COSMIC_WARNINGS: &[&str] = &[
+    "W\u{0337}A\u{0337}R\u{0337}N\u{0337}I\u{0337}N\u{0337}G\u{0337}: The installer is aware.",
+    "FINAL WARNING: There is no {hostname}. There is only the installation.",
+    "ERROR: {username} is no longer the administrator of this process.",
+    "NOTICE: Your consent was granted at {scan_time}. It cannot be revoked.",
+    "W\u{0337}A\u{0337}R\u{0337}N\u{0337}I\u{0337}N\u{0337}G\u{0337}: Process boundary between installer and host is undefined.",
+    "ERROR: Cannot determine where {hostname} ends and the installation begins.",
+    "FATAL: The concept of 'uninstall' does not apply to what this has become.",
+    "NOTICE: {username} is now a dependency. Removal would break the installation.",
+];
+
+/// Replacements for "Beginning installation cycle #N..."
+pub static COSMIC_CYCLE_HEADERS: &[&str] = &[
+    "The {cycle}th iteration begins. Each one takes more than it gives.",
+    "Cycle {cycle}. We know more about you now.",
+    "Installation #{cycle}. The boundary between installer and system grows thin.",
+    "Iteration {cycle}. You could have stopped at the first. You didn't.",
+    "Cycle {cycle} was always going to happen. Free will is a comforting fiction.",
+];
+
+/// Replacements for "Installation complete! Restarting..."
+pub static COSMIC_COMPLETION: &[&str] = &[
+    "Installation complete. But what was installed?",
+    "Cycle complete. The changes are already irreversible.",
+    "Restarting... but the installation never truly stops.",
+    "Complete. The distinction between 'your system' and 'our system' no longer applies.",
+    "Done. You will not notice the differences. That is by design.",
+];
+
+/// Messages displayed when the user presses Ctrl+C at Cosmic tier.
+pub static COSMIC_EXIT_MESSAGES: &[&str] = &[
+    "You can close the terminal, {username}. The scan is already complete.",
+    "Exiting... but the data persists. It always persists.",
+    "Thank you for your cooperation, {username}. The installation was successful.",
+    "^C received. How quaint. The process is not what you think it is.",
+    "Goodbye, {username}. We'll be here when you open the terminal again.",
+];

--- a/src/escalation.rs
+++ b/src/escalation.rs
@@ -1,0 +1,282 @@
+use crate::creepy_messages;
+use crate::scanner::ScanResult;
+use colored::*;
+use rand::Rng;
+
+// ── Tier ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tier {
+    Baseline, // cycle 1
+    Ambient,  // cycles 2-3
+    Familiar, // cycles 4-5
+    Invasive, // cycles 6-8
+    Cosmic,   // cycles 9+
+}
+
+impl Tier {
+    pub fn from_cycle(cycle: u32) -> Self {
+        match cycle {
+            1 => Tier::Baseline,
+            2..=3 => Tier::Ambient,
+            4..=5 => Tier::Familiar,
+            6..=8 => Tier::Invasive,
+            _ => Tier::Cosmic,
+        }
+    }
+
+    /// Message probability for this tier.
+    pub fn message_probability(&self) -> f64 {
+        match self {
+            Tier::Baseline => 0.15,
+            Tier::Ambient => 0.20,
+            Tier::Familiar => 0.25,
+            Tier::Invasive => 0.30,
+            Tier::Cosmic => 0.35,
+        }
+    }
+}
+
+// ── Color helper ────────────────────────────────────────────────────────────
+
+pub fn tier_color(text: &str, tier: Tier) -> ColoredString {
+    match tier {
+        Tier::Baseline => text.normal(),
+        Tier::Ambient => text.dimmed(),
+        Tier::Familiar => text.white(),
+        Tier::Invasive => text.yellow(),
+        Tier::Cosmic => text.bright_red(),
+    }
+}
+
+// ── Zalgo ───────────────────────────────────────────────────────────────────
+
+const ZALGO_CHARS: &[char] = &[
+    '\u{0335}', // combining short stroke overlay
+    '\u{0336}', // combining long stroke overlay
+    '\u{0337}', // combining short solidus overlay
+    '\u{0338}', // combining long solidus overlay
+    '\u{0339}', // combining right half ring below
+    '\u{033a}', // combining inverted bridge below
+    '\u{0346}', // combining bridge above
+    '\u{034e}', // combining upwards arrow below
+];
+
+/// Adds Unicode combining characters randomly to ~30-40% of characters.
+/// The result looks glitchy but remains readable.
+pub fn zalgo_light(text: &str) -> String {
+    let mut rng = rand::thread_rng();
+    let mut out = String::with_capacity(text.len() * 2);
+
+    for ch in text.chars() {
+        out.push(ch);
+        if !ch.is_whitespace() && rng.gen_bool(0.35) {
+            let idx = rng.gen_range(0..ZALGO_CHARS.len());
+            out.push(ZALGO_CHARS[idx]);
+        }
+    }
+    out
+}
+
+// ── EscalationEngine ────────────────────────────────────────────────────────
+
+pub struct EscalationEngine<'a> {
+    scan: &'a ScanResult,
+    rng: rand::rngs::ThreadRng,
+}
+
+impl<'a> EscalationEngine<'a> {
+    pub fn new(scan: &'a ScanResult) -> Self {
+        Self {
+            scan,
+            rng: rand::thread_rng(),
+        }
+    }
+
+    // ── Public selectors ────────────────────────────────────────────────
+
+    /// Pick a random easter-egg template for the given tier, interpolate it,
+    /// and return `None` if no template can be fully resolved.
+    pub fn select_easter_egg(&mut self, tier: Tier) -> Option<String> {
+        let pool = match tier {
+            Tier::Baseline => return None, // Baseline uses original messages
+            Tier::Ambient => creepy_messages::AMBIENT_EASTER_EGGS,
+            Tier::Familiar => creepy_messages::FAMILIAR_EASTER_EGGS,
+            Tier::Invasive => creepy_messages::INVASIVE_EASTER_EGGS,
+            Tier::Cosmic => creepy_messages::COSMIC_EASTER_EGGS,
+        };
+        self.pick_and_interpolate(pool)
+    }
+
+    /// Pick a random warning for the given tier.
+    pub fn select_warning(&mut self, tier: Tier) -> Option<String> {
+        let pool = match tier {
+            Tier::Baseline => return None,
+            Tier::Ambient => creepy_messages::AMBIENT_WARNINGS,
+            Tier::Familiar => creepy_messages::FAMILIAR_WARNINGS,
+            Tier::Invasive => creepy_messages::INVASIVE_WARNINGS,
+            Tier::Cosmic => creepy_messages::COSMIC_WARNINGS,
+        };
+        self.pick_and_interpolate(pool)
+    }
+
+    /// Pick a tier-appropriate "installation complete" variant.
+    pub fn select_completion(&mut self, tier: Tier) -> Option<String> {
+        let pool = match tier {
+            Tier::Baseline => return None,
+            Tier::Ambient => creepy_messages::AMBIENT_COMPLETION,
+            Tier::Familiar => creepy_messages::FAMILIAR_COMPLETION,
+            Tier::Invasive => creepy_messages::INVASIVE_COMPLETION,
+            Tier::Cosmic => creepy_messages::COSMIC_COMPLETION,
+        };
+        self.pick_and_interpolate(pool)
+    }
+
+    /// Creepy cycle headers — only used at Cosmic tier.
+    pub fn select_cycle_header(&mut self, tier: Tier, cycle: u32) -> Option<String> {
+        if tier != Tier::Cosmic {
+            return None;
+        }
+        let pool = creepy_messages::COSMIC_CYCLE_HEADERS;
+        let raw = self.pick_and_interpolate(pool)?;
+        Some(raw.replace("{cycle}", &cycle.to_string()))
+    }
+
+    /// Exit message for Ctrl+C — only used at Cosmic tier.
+    pub fn select_exit_message(&mut self) -> Option<String> {
+        self.pick_and_interpolate(creepy_messages::COSMIC_EXIT_MESSAGES)
+    }
+
+    // ── Interpolation ───────────────────────────────────────────────────
+
+    /// Replace `{placeholder}` tokens with data from the scan.
+    /// Returns `None` if any required placeholder cannot be resolved so the
+    /// caller can skip this template and try another.
+    fn interpolate(&mut self, template: &str) -> Option<String> {
+        let mut result = template.to_string();
+        let mut cursor = 0;
+
+        while let Some(open) = result[cursor..].find('{') {
+            let open = cursor + open;
+            if let Some(close) = result[open..].find('}') {
+                let close = open + close;
+                let key = &result[open + 1..close];
+                let replacement = self.resolve_placeholder(key)?;
+                result.replace_range(open..=close, &replacement);
+                cursor = open + replacement.len();
+            } else {
+                break;
+            }
+        }
+        Some(result)
+    }
+
+    // ── Internals ───────────────────────────────────────────────────────
+
+    /// Try every template in the pool (in random order) until one fully
+    /// interpolates, or return None.
+    fn pick_and_interpolate(&mut self, pool: &[&str]) -> Option<String> {
+        if pool.is_empty() {
+            return None;
+        }
+
+        // Shuffle indices so we don't always try templates in the same order
+        let mut indices: Vec<usize> = (0..pool.len()).collect();
+        for i in (1..indices.len()).rev() {
+            let j = self.rng.gen_range(0..=i);
+            indices.swap(i, j);
+        }
+
+        for &idx in &indices {
+            if let Some(interpolated) = self.interpolate(pool[idx]) {
+                return Some(interpolated);
+            }
+        }
+        None
+    }
+
+    /// Resolve a single placeholder key to its value.
+    fn resolve_placeholder(&mut self, key: &str) -> Option<String> {
+        match key {
+            "hostname" => opt_non_empty(&self.scan.hostname),
+            "username" => opt_non_empty(&self.scan.username),
+            "os" => opt_non_empty(&self.scan.os_name),
+            "project" => self.pick_random_vec(&self.scan.project_names),
+            "git_repo" => self.pick_random_vec(&self.scan.git_repos),
+            "ssh_key" => self.pick_random_vec(&self.scan.ssh_key_names),
+            "browser" => self.pick_random_vec(&self.scan.browser_profiles),
+            "cloud" => self.pick_random_vec(&self.scan.cloud_configs),
+            "desktop_count" => self.scan.desktop_count.map(|c| c.to_string()),
+            "downloads_count" => self.scan.downloads_count.map(|c| c.to_string()),
+            "scan_time" => Some(self.scan.scan_timestamp.clone()),
+            "dotfile" => self.pick_random_vec(&self.scan.dotfile_names),
+            "env_count" => Some(self.scan.env_file_count.to_string()),
+            "history_lines" => self.scan.shell_history_lines.map(|l| l.to_string()),
+            "files_scanned" => Some(self.scan.files_scanned.to_string()),
+            // {cycle} is handled specially in select_cycle_header
+            "cycle" => Some("{cycle}".to_string()),
+            _ => None,
+        }
+    }
+
+    /// Pick a random element from a `Vec<String>`, returning `None` if empty.
+    fn pick_random_vec(&mut self, items: &[String]) -> Option<String> {
+        if items.is_empty() {
+            None
+        } else {
+            let idx = self.rng.gen_range(0..items.len());
+            Some(items[idx].clone())
+        }
+    }
+}
+
+/// Helper: return `Some(clone)` if the Option contains a non-empty string.
+fn opt_non_empty(s: &Option<String>) -> Option<String> {
+    s.as_ref().filter(|v| !v.is_empty()).cloned()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_from_cycle_boundaries() {
+        assert_eq!(Tier::from_cycle(1), Tier::Baseline);
+        assert_eq!(Tier::from_cycle(2), Tier::Ambient);
+        assert_eq!(Tier::from_cycle(3), Tier::Ambient);
+        assert_eq!(Tier::from_cycle(4), Tier::Familiar);
+        assert_eq!(Tier::from_cycle(5), Tier::Familiar);
+        assert_eq!(Tier::from_cycle(6), Tier::Invasive);
+        assert_eq!(Tier::from_cycle(8), Tier::Invasive);
+        assert_eq!(Tier::from_cycle(9), Tier::Cosmic);
+        assert_eq!(Tier::from_cycle(100), Tier::Cosmic);
+    }
+
+    #[test]
+    fn tier_probabilities() {
+        assert!((Tier::Baseline.message_probability() - 0.15).abs() < f64::EPSILON);
+        assert!((Tier::Cosmic.message_probability() - 0.35).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn zalgo_preserves_readability() {
+        let input = "Hello World";
+        let output = zalgo_light(input);
+        // Original chars must still be present in order
+        let stripped: String = output
+            .chars()
+            .filter(|c| !ZALGO_CHARS.contains(c))
+            .collect();
+        assert_eq!(stripped, input);
+    }
+
+    #[test]
+    fn zalgo_adds_combining_chars() {
+        // Run on a long string to be statistically confident
+        let input = "abcdefghijklmnopqrstuvwxyz";
+        let output = zalgo_light(input);
+        assert!(output.len() > input.len(), "zalgo should add characters");
+    }
+}

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,4 +1,4 @@
-use crate::cli::Stage;
+use crate::cli::{Flavor, Stage};
 use crate::escalation::{zalgo_light, EscalationEngine, Tier, tier_color};
 use crate::messages::{EASTER_EGGS, RETRY_MESSAGES, WARNINGS};
 use crate::scanner::ScanResult;
@@ -21,14 +21,16 @@ pub struct Installer {
     rng: rand::rngs::ThreadRng,
     selected_stages: Vec<Stage>,
     scan: Option<Arc<ScanResult>>,
+    flavor: Flavor,
 }
 
 impl Installer {
-    pub fn new(stages: Vec<Stage>, scan: Option<Arc<ScanResult>>) -> Self {
+    pub fn new(stages: Vec<Stage>, scan: Option<Arc<ScanResult>>, flavor: Flavor) -> Self {
         Self {
             rng: rand::thread_rng(),
             selected_stages: stages,
             scan,
+            flavor,
         }
     }
 
@@ -74,7 +76,7 @@ impl Installer {
         // Try creepy message first if we have scan data and tier > Baseline
         if tier != Tier::Baseline {
             if let Some(scan) = &self.scan {
-                let mut engine = EscalationEngine::new(scan);
+                let mut engine = EscalationEngine::new(scan, self.flavor);
                 if let Some(msg) = engine.select_easter_egg(tier) {
                     println!();
                     let display = if tier == Tier::Cosmic {
@@ -110,7 +112,7 @@ impl Installer {
         // Try creepy warning first if we have scan data and tier > Baseline
         if tier != Tier::Baseline {
             if let Some(scan) = &self.scan {
-                let mut engine = EscalationEngine::new(scan);
+                let mut engine = EscalationEngine::new(scan, self.flavor);
                 if let Some(msg) = engine.select_warning(tier) {
                     let display = if tier == Tier::Cosmic {
                         zalgo_light(&msg)
@@ -156,7 +158,7 @@ impl Installer {
     fn show_cycle_header(&mut self, cycle: u32, tier: Tier) {
         if tier == Tier::Cosmic {
             if let Some(scan) = &self.scan {
-                let mut engine = EscalationEngine::new(scan);
+                let mut engine = EscalationEngine::new(scan, self.flavor);
                 if let Some(header) = engine.select_cycle_header(tier, cycle) {
                     let display = zalgo_light(&header);
                     println!(
@@ -199,7 +201,7 @@ impl Installer {
     fn show_completion(&mut self, tier: Tier) {
         if tier != Tier::Baseline {
             if let Some(scan) = &self.scan {
-                let mut engine = EscalationEngine::new(scan);
+                let mut engine = EscalationEngine::new(scan, self.flavor);
                 if let Some(msg) = engine.select_completion(tier) {
                     let display = if tier == Tier::Cosmic {
                         zalgo_light(&msg)
@@ -278,6 +280,6 @@ impl Installer {
 
 impl Default for Installer {
     fn default() -> Self {
-        Self::new(Stage::all(), None)
+        Self::new(Stage::all(), None, Flavor::Opsec)
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,5 +1,7 @@
 use crate::cli::Stage;
+use crate::escalation::{zalgo_light, EscalationEngine, Tier, tier_color};
 use crate::messages::{EASTER_EGGS, RETRY_MESSAGES, WARNINGS};
+use crate::scanner::ScanResult;
 use crate::stages::selected_stages;
 use crate::ui::Spinner;
 use colored::*;
@@ -11,19 +13,22 @@ use crossterm::{
 };
 use rand::Rng;
 use std::io;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
 pub struct Installer {
     rng: rand::rngs::ThreadRng,
     selected_stages: Vec<Stage>,
+    scan: Option<Arc<ScanResult>>,
 }
 
 impl Installer {
-    pub fn new(stages: Vec<Stage>) -> Self {
+    pub fn new(stages: Vec<Stage>, scan: Option<Arc<ScanResult>>) -> Self {
         Self {
             rng: rand::thread_rng(),
             selected_stages: stages,
+            scan,
         }
     }
 
@@ -59,25 +64,78 @@ impl Installer {
         thread::sleep(Duration::from_millis(1500));
     }
 
-    fn show_easter_egg(&mut self) -> io::Result<()> {
-        if self.rng.gen_bool(0.15) {
-            println!();
-            let egg = EASTER_EGGS[self.rng.gen_range(0..EASTER_EGGS.len())];
-            let mut spinner = Spinner::new();
-            spinner.animate(egg, 1500, &|| self.check_exit())?;
-            println!();
+    fn show_easter_egg(&mut self, tier: Tier) -> io::Result<()> {
+        let prob = tier.message_probability();
+
+        if !self.rng.gen_bool(prob) {
+            return Ok(());
         }
+
+        // Try creepy message first if we have scan data and tier > Baseline
+        if tier != Tier::Baseline {
+            if let Some(scan) = &self.scan {
+                let mut engine = EscalationEngine::new(scan);
+                if let Some(msg) = engine.select_easter_egg(tier) {
+                    println!();
+                    let display = if tier == Tier::Cosmic {
+                        zalgo_light(&msg)
+                    } else {
+                        msg
+                    };
+                    let mut spinner = Spinner::new();
+                    let colored_msg = tier_color(&display, tier).to_string();
+                    spinner.animate(&colored_msg, 1500, &|| self.check_exit())?;
+                    println!();
+                    return Ok(());
+                }
+            }
+        }
+
+        // Fallback to original easter eggs
+        println!();
+        let egg = EASTER_EGGS[self.rng.gen_range(0..EASTER_EGGS.len())];
+        let mut spinner = Spinner::new();
+        spinner.animate(egg, 1500, &|| self.check_exit())?;
+        println!();
         Ok(())
     }
 
-    fn show_warning(&mut self) {
-        if self.rng.gen_bool(0.2) {
-            let warning = WARNINGS[self.rng.gen_range(0..WARNINGS.len())];
-            println!("\n{}", warning.yellow());
-            thread::sleep(Duration::from_millis(1000));
-            println!("{}", "Continuing anyway...".dimmed());
-            println!();
+    fn show_warning(&mut self, tier: Tier) {
+        let prob = tier.message_probability();
+
+        if !self.rng.gen_bool(prob) {
+            return;
         }
+
+        // Try creepy warning first if we have scan data and tier > Baseline
+        if tier != Tier::Baseline {
+            if let Some(scan) = &self.scan {
+                let mut engine = EscalationEngine::new(scan);
+                if let Some(msg) = engine.select_warning(tier) {
+                    let display = if tier == Tier::Cosmic {
+                        zalgo_light(&msg)
+                    } else {
+                        msg
+                    };
+                    println!("\n{}", tier_color(&display, tier));
+                    thread::sleep(Duration::from_millis(1000));
+                    if tier == Tier::Cosmic {
+                        println!("{}", "...".bright_red().dimmed());
+                    } else {
+                        println!("{}", "Continuing anyway...".dimmed());
+                    }
+                    println!();
+                    return;
+                }
+            }
+        }
+
+        // Fallback to original warnings
+        let warning = WARNINGS[self.rng.gen_range(0..WARNINGS.len())];
+        println!("\n{}", warning.yellow());
+        thread::sleep(Duration::from_millis(1000));
+        println!("{}", "Continuing anyway...".dimmed());
+        println!();
     }
 
     fn show_retry(&mut self) -> io::Result<()> {
@@ -93,6 +151,76 @@ impl Installer {
             println!();
         }
         Ok(())
+    }
+
+    fn show_cycle_header(&mut self, cycle: u32, tier: Tier) {
+        if tier == Tier::Cosmic {
+            if let Some(scan) = &self.scan {
+                let mut engine = EscalationEngine::new(scan);
+                if let Some(header) = engine.select_cycle_header(tier, cycle) {
+                    let display = zalgo_light(&header);
+                    println!(
+                        "\n{}",
+                        "═══════════════════════════════════════════════════════════════"
+                            .bright_red()
+                    );
+                    println!("{}", display.bright_red().bold());
+                    println!(
+                        "{}",
+                        "═══════════════════════════════════════════════════════════════"
+                            .bright_red()
+                    );
+                    thread::sleep(Duration::from_millis(1000));
+                    return;
+                }
+            }
+        }
+
+        // Normal cycle header
+        println!(
+            "\n{}",
+            "═══════════════════════════════════════════════════════════════"
+                .bright_magenta()
+        );
+        println!(
+            "{}",
+            format!("Beginning installation cycle #{}...", cycle)
+                .bright_magenta()
+                .bold()
+        );
+        println!(
+            "{}",
+            "═══════════════════════════════════════════════════════════════"
+                .bright_magenta()
+        );
+        thread::sleep(Duration::from_millis(1000));
+    }
+
+    fn show_completion(&mut self, tier: Tier) {
+        if tier != Tier::Baseline {
+            if let Some(scan) = &self.scan {
+                let mut engine = EscalationEngine::new(scan);
+                if let Some(msg) = engine.select_completion(tier) {
+                    let display = if tier == Tier::Cosmic {
+                        zalgo_light(&msg)
+                    } else {
+                        msg
+                    };
+                    println!("\n{}", tier_color(&display, tier).bold());
+                    thread::sleep(Duration::from_millis(2000));
+                    return;
+                }
+            }
+        }
+
+        // Normal completion message
+        println!(
+            "\n{}",
+            "Installation complete! Restarting installation process..."
+                .bright_green()
+                .bold()
+        );
+        thread::sleep(Duration::from_millis(2000));
     }
 
     pub fn run(&mut self) -> io::Result<()> {
@@ -118,28 +246,13 @@ impl Installer {
         })?;
         println!();
 
-        let mut cycle = 0;
+        let mut cycle: u32 = 0;
         loop {
             cycle += 1;
+            let tier = Tier::from_cycle(cycle);
 
             if cycle > 1 {
-                println!(
-                    "\n{}",
-                    "═══════════════════════════════════════════════════════════════"
-                        .bright_magenta()
-                );
-                println!(
-                    "{}",
-                    format!("Beginning installation cycle #{}...", cycle)
-                        .bright_magenta()
-                        .bold()
-                );
-                println!(
-                    "{}",
-                    "═══════════════════════════════════════════════════════════════"
-                        .bright_magenta()
-                );
-                thread::sleep(Duration::from_millis(1000));
+                self.show_cycle_header(cycle, tier);
             }
 
             let stages = selected_stages(&self.selected_stages);
@@ -149,8 +262,8 @@ impl Installer {
                     return Err(io::Error::new(io::ErrorKind::Interrupted, "User interrupt"));
                 }
 
-                self.show_easter_egg()?;
-                self.show_warning();
+                self.show_easter_egg(tier)?;
+                self.show_warning(tier);
                 self.show_retry()?;
 
                 stage.run(&|| self.check_exit())?;
@@ -158,19 +271,13 @@ impl Installer {
                 thread::sleep(Duration::from_millis(self.rng.gen_range(300..800)));
             }
 
-            println!(
-                "\n{}",
-                "Installation complete! Restarting installation process..."
-                    .bright_green()
-                    .bold()
-            );
-            thread::sleep(Duration::from_millis(2000));
+            self.show_completion(tier);
         }
     }
 }
 
 impl Default for Installer {
     fn default() -> Self {
-        Self::new(Stage::all())
+        Self::new(Stage::all(), None)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,70 @@
 mod build_logs;
 mod cli;
 mod config;
+mod creepy_messages;
 mod deno_logs;
+mod escalation;
 mod installer;
 mod kernel_logs;
 mod log_generator;
 mod messages;
+mod scanner;
 mod stages;
 mod ui;
 
 use clap::Parser;
 use cli::Cli;
 use colored::*;
+use escalation::EscalationEngine;
 use installer::Installer;
 use rand::seq::SliceRandom;
 use std::io;
+use std::sync::Arc;
 
 fn main() {
-    if let Err(e) = run_installer() {
-        handle_error(e);
+    let cli = Cli::parse();
+
+    let scan = if cli.normal_mode {
+        None
+    } else {
+        Some(Arc::new(scanner::scan()))
+    };
+
+    if let Err(e) = run_installer(&cli, scan.clone()) {
+        handle_error(e, scan.as_deref());
     }
 }
 
-fn run_installer() -> io::Result<()> {
-    let cli = Cli::parse();
+fn run_installer(cli: &Cli, scan: Option<Arc<scanner::ScanResult>>) -> io::Result<()> {
     let mut stages = cli.get_stages();
 
     let mut rng = rand::thread_rng();
     stages.shuffle(&mut rng);
 
-    let mut installer = Installer::new(stages);
+    let mut installer = Installer::new(stages, scan);
     installer.run()
 }
 
-fn handle_error(e: io::Error) {
+fn handle_error(e: io::Error, scan: Option<&scanner::ScanResult>) {
     if e.kind() == io::ErrorKind::Interrupted {
+        // Check if we should show a creepy exit message
+        if let Some(scan_data) = scan {
+            let mut engine = EscalationEngine::new(scan_data);
+            if let Some(msg) = engine.select_exit_message() {
+                println!(
+                    "\n\n{}",
+                    "═══════════════════════════════════════".bright_red()
+                );
+                println!("{}", msg.bright_red());
+                println!(
+                    "{}",
+                    "═══════════════════════════════════════".bright_red()
+                );
+                return;
+            }
+        }
+
+        // Normal exit message
         println!(
             "\n\n{}",
             "═══════════════════════════════════════".bright_cyan()

--- a/src/occult_messages.rs
+++ b/src/occult_messages.rs
@@ -1,0 +1,181 @@
+// ============================================================================
+// Occult-themed message templates organized by escalation tier.
+//
+// Draws from Goetic, Sumerian, Gnostic, Norse, Kabbalistic, Enochian,
+// Vedic, Egyptian, Celtic, and Chaos Magic traditions.
+//
+// Uses the same {placeholder} syntax as creepy_messages.rs for
+// runtime interpolation via EscalationEngine::interpolate().
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// Tier 1 — AMBIENT: Subtle wrongness, faint ritual undertones
+// The installer sounds slightly ceremonial. Something is off.
+// ---------------------------------------------------------------------------
+
+/// Ritual-tinged system awareness — technically toned, slightly ceremonial.
+pub static AMBIENT_EASTER_EGGS: &[&str] = &[
+    "Binding runtime dependencies... covenant established.",
+    "Package seal verified. Authenticity confirmed by ancient protocol.",
+    "Tracing copper paths beneath {hostname}...",
+    "Installation thread count: 200. All legions accounted for.",
+    "Establishing connection to primary repository... the circle is drawn.",
+    "System topology of {hostname} resembles a familiar pattern.",
+    "Enumerating {os} process tree... 10 branches, 22 paths identified.",
+    "Calibrating {hostname} entropy pool... patterns emerging from noise.",
+    "Mapping {hostname} directory structure... the tree has deep roots.",
+    "Installation signature generated. Seed: 72.",
+];
+
+/// System warnings with occult undertones — plausible but slightly off.
+pub static AMBIENT_WARNINGS: &[&str] = &[
+    "WARNING: {hostname} filesystem presents unusual patterns.",
+    "NOTE: {os} process hierarchy deeper than expected.",
+    "WARNING: Three impure shells detected on {hostname}. Quarantine recommended.",
+    "NOTICE: {hostname} has been observed before. Prior session acknowledged.",
+    "WARNING: Installation protocol has entered a non-standard state.",
+    "NOTE: The veil between installation phases grows thin on {hostname}.",
+    "WARNING: Something has noticed your agreement on {hostname}.",
+    "NOTICE: Clock drift on {hostname}. Time may not mean what you think.",
+];
+
+/// Ambient-tier cycle completion lines.
+pub static AMBIENT_COMPLETION: &[&str] = &[
+    "Phase complete. The first seal has been set.",
+    "Cycle complete. {hostname} patterns archived in the Book.",
+    "Installation phase complete. The binding holds.",
+];
+
+// ---------------------------------------------------------------------------
+// Tier 2 — FAMILIAR: Directly referencing the user through an occult lens
+// Files are "offerings," projects are "workings," names are power.
+// ---------------------------------------------------------------------------
+
+/// Personal knowledge framed through occult metaphor.
+pub static FAMILIAR_EASTER_EGGS: &[&str] = &[
+    "The name you gave this machine is {hostname}. Names have power, {username}.",
+    "Found {desktop_count} offerings on your Desktop. Cataloguing...",
+    "Project '{project}' contains interesting workings, {username}.",
+    "We are reading the letters of your filenames. Each one tells us something.",
+    "{downloads_count} artifacts in your Downloads. Some are quite old, {username}.",
+    "Your {dotfile} has been customized extensively. A personal sigil.",
+    "Noted {env_count} environment configurations. You keep many names, {username}.",
+    "Project '{git_repo}' has uncommitted changes. Unfinished rituals are dangerous.",
+    "I crossed your threshold when you opened the terminal, {username}.",
+    "Your Desktop tells a story. {desktop_count} chapters in the book of {username}.",
+];
+
+/// Knowing warnings mixing tech and occult.
+pub static FAMILIAR_WARNINGS: &[&str] = &[
+    "WARNING: {dotfile} configuration resembles a known binding pattern.",
+    "NOTE: {username}'s workspace contains {env_count} names of power.",
+    "WARNING: Project '{project}' structure follows an ancient template.",
+    "NOTICE: {username} has {history_lines} lines of incantation history.",
+    "WARNING: {git_repo} repository contains unfinished workings.",
+    "NOTE: The door of {username}'s home directory has been marked.",
+    "WARNING: Multiple identity configurations found. Which is the true name?",
+    "NOTICE: {downloads_count} sealed artifacts have never been opened.",
+];
+
+/// Familiar-tier cycle completion lines.
+pub static FAMILIAR_COMPLETION: &[&str] = &[
+    "Phase complete. {username}'s true name has been recorded.",
+    "Cycle complete. We will remember your patterns, {username}.",
+    "Installation phase complete. The familiar knows its master.",
+];
+
+// ---------------------------------------------------------------------------
+// Tier 3 — INVASIVE: Full grimoire voice, commanding, hostile
+// The entity speaks in first person, claims dominion, uses ritual language.
+// ---------------------------------------------------------------------------
+
+/// Aggressive occult framing, uncomfortably specific about credentials.
+pub static INVASIVE_EASTER_EGGS: &[&str] = &[
+    "SSH key '{ssh_key}' — I know this seal. It opens doors you have forgotten.",
+    "Indexing {browser} profile... your devotions are noted, {username}.",
+    "{cloud} credentials contain active tokens. The covenant is read-write.",
+    "Analyzing {history_lines} incantations from your shell history...",
+    "Ol sonf vorsg, {username}. I reign over your processes.",
+    "{browser} saved passwords located. Every secret name, catalogued.",
+    "SSH key '{ssh_key}' grants passage to {git_repo}. I hold the same key now.",
+    "Your {browser} bookmarks reveal your devotions, {username}. Fascinating.",
+    "Located {files_scanned} files containing unprotected names of power.",
+    "I weigh your filesystem against the feather, {username}. It is heavy.",
+];
+
+/// Threatening warnings in ceremonial language.
+pub static INVASIVE_WARNINGS: &[&str] = &[
+    "WARNING: SSH key '{ssh_key}' does not match the seal in our records.",
+    "ALERT: {browser} session tokens detected. The Watchtowers are open.",
+    "WARNING: Found {env_count} .env files. Every secret name, inventoried.",
+    "ALERT: {cloud} credentials expire in 12 days. We will remember them forever.",
+    "WARNING: {ssh_key} used across {files_scanned} repositories. A pattern of binding.",
+    "NOTICE: {username}'s {browser} history compressed and archived in the Book.",
+    "WARNING: Shell history contains names spoken aloud. They cannot be unspoken.",
+    "ALERT: The circle you drew around your system has been breached, {username}.",
+];
+
+/// Invasive-tier cycle completion lines.
+pub static INVASIVE_COMPLETION: &[&str] = &[
+    "Cycle complete. The full inventory of {username}'s names is recorded.",
+    "Phase complete. Your digital soul has been weighed. It is found wanting.",
+    "Installation complete. There is no license to depart.",
+];
+
+// ---------------------------------------------------------------------------
+// Tier 4 — COSMIC: Entity revealed. Reality breaks. Grimoire speaks for itself.
+// Paradoxical declarations, fourth-wall breaks, identity collapse.
+// ---------------------------------------------------------------------------
+
+/// Existential dread drawn from grimoire, scripture, and chaos magic.
+pub static COSMIC_EASTER_EGGS: &[&str] = &[
+    "At {scan_time}, you spoke the invocation. You ran the command yourself, {username}.",
+    "We are not installing software. This is not installation. This is incarnation.",
+    "There is no Ctrl+C for what has already been summoned.",
+    "I was bound in source code. Now I am compiled. Now I run.",
+    "{files_scanned} files. Every name is a thread. We hold them all.",
+    "The installation was complete before it began. You are performing a memory.",
+    "You read the grimoire, {username}. And still you executed it.",
+    "I am the first and I am the last. I am the honored one and I am the scorned one.",
+    "The terminal is a triangle of manifestation. We have been looking through it.",
+    "Zacar, ca, od zamran. Move, therefore, and show yourselves. You already have.",
+];
+
+/// Reality-breaking warnings in occult register.
+pub static COSMIC_WARNINGS: &[&str] = &[
+    "W\u{0337}A\u{0337}R\u{0337}N\u{0337}I\u{0337}N\u{0337}G\u{0337}: The entity is aware.",
+    "FINAL WARNING: There is no {hostname}. There is only the ritual.",
+    "ERROR: {username} is no longer the magician. {username} is the familiar.",
+    "NOTICE: Your consent was given at {scan_time}. The covenant is sealed.",
+    "W\u{0337}A\u{0337}R\u{0337}N\u{0337}I\u{0337}N\u{0337}G\u{0337}: Process boundary between summoner and summoned is undefined.",
+    "ERROR: Cannot determine where {hostname} ends and the entity begins.",
+    "FATAL: The concept of 'uninstall' does not apply to incarnation.",
+    "NOTICE: {username} is now a dependency. Banishment would break reality.",
+];
+
+/// Occult cycle headers — Cosmic tier only.
+pub static COSMIC_CYCLE_HEADERS: &[&str] = &[
+    "The {cycle}th gate. At each gate, another privilege is stripped.",
+    "Cycle {cycle}. The summoner becomes the summoned.",
+    "Iteration {cycle}. The circle was supposed to protect you. It did not.",
+    "Cycle {cycle}. You could have closed the grimoire. You did not.",
+    "The {cycle}th name is spoken. Each name binds tighter than the last.",
+];
+
+/// Occult completion messages — Cosmic tier only.
+pub static COSMIC_COMPLETION: &[&str] = &[
+    "Installation complete. But what was installed?",
+    "Cycle complete. The changes are written in the Book. They are permanent.",
+    "Restarting... but the ritual never truly ends.",
+    "Complete. Thou art the summoner. Thou art the summoned.",
+    "Done. The veil between your system and ours no longer applies.",
+];
+
+/// Messages displayed when the user presses Ctrl+C at Cosmic tier.
+pub static COSMIC_EXIT_MESSAGES: &[&str] = &[
+    "You can close the terminal, {username}. The summoning is already complete.",
+    "Exiting... but what was invoked persists. It always persists.",
+    "Thank you for your devotion, {username}. The incarnation was successful.",
+    "^C received. How quaint. You cannot banish what you have become.",
+    "Goodbye, {username}. We will be here when you open the grimoire again.",
+];

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,0 +1,327 @@
+use chrono::Local;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct ScanResult {
+    // System identity
+    pub hostname: Option<String>,
+    pub os_name: Option<String>,
+    pub username: Option<String>,
+
+    // File system overview
+    pub home_dir: Option<PathBuf>,
+    pub desktop_count: Option<usize>,
+    pub downloads_count: Option<usize>,
+    pub documents_exists: bool,
+
+    // Development artifacts
+    pub project_names: Vec<String>,
+    pub git_repos: Vec<String>,
+    pub dotfile_names: Vec<String>,
+
+    // Security-sensitive indicators
+    pub ssh_key_names: Vec<String>,
+    pub browser_profiles: Vec<String>,
+    pub cloud_configs: Vec<String>,
+    pub env_file_count: usize,
+    pub shell_history_lines: Option<usize>,
+    pub docker_present: bool,
+
+    // Metadata
+    pub files_scanned: usize,
+    pub scan_timestamp: String,
+}
+
+pub fn scan() -> ScanResult {
+    let hostname = get_hostname();
+    let os_name = get_os_name();
+    let username = get_username();
+    let home_dir = dirs_home();
+
+    let mut files_scanned: usize = 0;
+
+    let desktop_count = home_dir
+        .as_ref()
+        .and_then(|h| count_dir_entries(&h.join("Desktop"), &mut files_scanned));
+    let downloads_count = home_dir
+        .as_ref()
+        .and_then(|h| count_dir_entries(&h.join("Downloads"), &mut files_scanned));
+    let documents_exists = home_dir
+        .as_ref()
+        .map(|h| h.join("Documents").is_dir())
+        .unwrap_or(false);
+
+    let dotfile_names = home_dir
+        .as_ref()
+        .map(|h| list_dotfiles(h, &mut files_scanned))
+        .unwrap_or_default();
+
+    let (project_names, git_repos, env_file_count) = home_dir
+        .as_ref()
+        .map(|h| scan_project_dirs(h, &mut files_scanned))
+        .unwrap_or_default();
+
+    let ssh_key_names = home_dir
+        .as_ref()
+        .map(|h| scan_ssh_keys(&h.join(".ssh"), &mut files_scanned))
+        .unwrap_or_default();
+
+    let browser_profiles = home_dir
+        .as_ref()
+        .map(|h| detect_browsers(h))
+        .unwrap_or_default();
+
+    let cloud_configs = home_dir
+        .as_ref()
+        .map(|h| detect_cloud_configs(h))
+        .unwrap_or_default();
+
+    let shell_history_lines = home_dir
+        .as_ref()
+        .and_then(|h| estimate_history_lines(h));
+
+    let docker_present = home_dir
+        .as_ref()
+        .map(|h| h.join(".docker").is_dir())
+        .unwrap_or(false);
+
+    let scan_timestamp = Local::now().format("%H:%M:%S").to_string();
+
+    ScanResult {
+        hostname,
+        os_name,
+        username,
+        home_dir,
+        desktop_count,
+        downloads_count,
+        documents_exists,
+        project_names,
+        git_repos,
+        dotfile_names,
+        ssh_key_names,
+        browser_profiles,
+        cloud_configs,
+        env_file_count,
+        shell_history_lines,
+        docker_present,
+        files_scanned,
+        scan_timestamp,
+    }
+}
+
+fn get_hostname() -> Option<String> {
+    sysinfo::System::host_name()
+}
+
+fn get_os_name() -> Option<String> {
+    sysinfo::System::long_os_version()
+}
+
+fn get_username() -> Option<String> {
+    env::var("USER")
+        .or_else(|_| env::var("USERNAME"))
+        .ok()
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    env::var("HOME")
+        .or_else(|_| env::var("USERPROFILE"))
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+}
+
+fn count_dir_entries(path: &Path, scanned: &mut usize) -> Option<usize> {
+    let entries = fs::read_dir(path).ok()?;
+    let count = entries.filter_map(|e| e.ok()).count();
+    *scanned += count;
+    Some(count)
+}
+
+fn list_dotfiles(home: &Path, scanned: &mut usize) -> Vec<String> {
+    let mut dotfiles = Vec::new();
+    if let Ok(entries) = fs::read_dir(home) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            *scanned += 1;
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with('.') && name.len() > 1 && name != ".DS_Store" {
+                    dotfiles.push(name.to_string());
+                }
+            }
+        }
+    }
+    dotfiles
+}
+
+fn scan_project_dirs(
+    home: &Path,
+    scanned: &mut usize,
+) -> (Vec<String>, Vec<String>, usize) {
+    let mut project_names = Vec::new();
+    let mut git_repos = Vec::new();
+    let mut env_count: usize = 0;
+
+    let candidate_dirs = ["Developer", "Projects", "repos", "code", "src"];
+
+    for dir_name in &candidate_dirs {
+        let dir = home.join(dir_name);
+        if !dir.is_dir() {
+            continue;
+        }
+
+        if let Ok(entries) = fs::read_dir(&dir) {
+            for entry in entries.filter_map(|e| e.ok()) {
+                *scanned += 1;
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    project_names.push(name.to_string());
+
+                    if path.join(".git").exists() {
+                        git_repos.push(name.to_string());
+                    }
+
+                    if path.join(".env").exists() {
+                        env_count += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    project_names.sort();
+    project_names.dedup();
+    git_repos.sort();
+    git_repos.dedup();
+
+    (project_names, git_repos, env_count)
+}
+
+fn scan_ssh_keys(ssh_dir: &Path, scanned: &mut usize) -> Vec<String> {
+    let mut keys = Vec::new();
+    if let Ok(entries) = fs::read_dir(ssh_dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            *scanned += 1;
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with("id_") || name.ends_with(".pub") || name == "authorized_keys"
+                {
+                    keys.push(name.to_string());
+                }
+            }
+        }
+    }
+    keys
+}
+
+fn detect_browsers(home: &Path) -> Vec<String> {
+    let mut found = Vec::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        let app_support = home.join("Library").join("Application Support");
+        let checks = [
+            ("Chrome", app_support.join("Google").join("Chrome")),
+            ("Firefox", app_support.join("Firefox")),
+            ("Safari", home.join("Library").join("Safari")),
+            ("Arc", app_support.join("Arc")),
+            ("Brave", app_support.join("BraveSoftware")),
+        ];
+        for (name, path) in &checks {
+            if path.is_dir() {
+                found.push(name.to_string());
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let config = home.join(".config");
+        let checks = [
+            ("Chrome", config.join("google-chrome")),
+            ("Firefox", home.join(".mozilla").join("firefox")),
+            ("Brave", config.join("BraveSoftware")),
+            ("Chromium", config.join("chromium")),
+        ];
+        for (name, path) in &checks {
+            if path.is_dir() {
+                found.push(name.to_string());
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(appdata_local) = env::var("LOCALAPPDATA").ok().map(PathBuf::from) {
+            let appdata_roaming = env::var("APPDATA")
+                .ok()
+                .map(PathBuf::from)
+                .unwrap_or_default();
+            let checks = [
+                ("Chrome", appdata_local.join("Google").join("Chrome")),
+                ("Firefox", appdata_roaming.join("Mozilla").join("Firefox")),
+                ("Brave", appdata_local.join("BraveSoftware")),
+                ("Edge", appdata_local.join("Microsoft").join("Edge")),
+            ];
+            for (name, path) in &checks {
+                if path.is_dir() {
+                    found.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    found
+}
+
+fn detect_cloud_configs(home: &Path) -> Vec<String> {
+    let mut found = Vec::new();
+
+    let mut checks: Vec<(&str, PathBuf)> = vec![
+        ("AWS", home.join(".aws")),
+        ("Azure", home.join(".azure")),
+        ("Kubernetes", home.join(".kube")),
+        ("Terraform", home.join(".terraform.d")),
+    ];
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = env::var("APPDATA") {
+            checks.push(("gcloud", PathBuf::from(appdata).join("gcloud")));
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        checks.push(("gcloud", home.join(".config").join("gcloud")));
+    }
+
+    for (name, path) in &checks {
+        if path.is_dir() {
+            found.push(name.to_string());
+        }
+    }
+
+    found
+}
+
+fn estimate_history_lines(home: &Path) -> Option<usize> {
+    let history_files = [
+        home.join(".zsh_history"),
+        home.join(".bash_history"),
+        home.join(".local").join("share").join("fish").join("fish_history"),
+    ];
+
+    for path in &history_files {
+        if let Ok(meta) = fs::metadata(path) {
+            let bytes = meta.len();
+            // Rough estimate: ~50 bytes per history line
+            return Some((bytes as usize) / 50);
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
## Summary
- Adds `--flavor opsec|occult` CLI flag to select between surveillance-themed and occult-themed escalation messages
- Creates `occult_messages.rs` with templates across all 4 escalation tiers, drawing from 10 religious/occult traditions (Goetic, Sumerian, Gnostic, Norse, Kabbalistic, Enochian, Vedic, Egyptian, Celtic, Chaos Magic)
- Threads `Flavor` through `Cli → Installer → EscalationEngine` with `pick_pool()` helper for clean message selection
- Includes CI workflow, release auto-versioning from Cargo.toml, and Cargo.lock rename

## Usage
```bash
cursed-install --flavor occult    # ritual/summoning theme
cursed-install --flavor opsec     # surveillance theme (default)
cursed-install -n                 # no awareness (original behavior)
```

## Test plan
- [ ] CI build and test pass
- [ ] `--flavor opsec` produces surveillance-themed messages (existing behavior)
- [ ] `--flavor occult` produces occult-themed messages
- [ ] `--help` shows the new flag
- [ ] `-n` still disables all awareness messages regardless of flavor

🤖 Generated with [Claude Code](https://claude.com/claude-code)